### PR TITLE
/home: Remove count of status

### DIFF
--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -3538,42 +3538,8 @@ any '/visit' => sub {
     );
 };
 
-get '/' => sub {
-    my $self = shift;
-
-    my $rs = $DB->resultset('Clothes')->search(
-        undef,
-        {
-            select   => [ 'status_id', { count => 'me.status_id' } ],
-            as       => [ qw/ id count / ],
-            group_by => [ qw/ status_id / ],
-            order_by => [ qw/ status_id / ],
-        },
-    );
-
-    my %status = (
-        all => $DB->resultset('Clothes')->count,
-        1   => 0,
-        2   => 0,
-        3   => 0,
-        4   => 0,
-        5   => 0,
-        6   => 0,
-        7   => 0,
-        8   => 0,
-        9   => 0,
-        11  => 0,
-    );
-    while ( my $s = $rs->next ) {
-        my $id    = $s->get_column('id');
-        my $count = $s->get_column('count');
-        $status{$id} = $count;
-    }
-
-    $self->render( 'home', status => \%status );
-};
-
-get '/new-clothes'  => 'new-clothes';
+get '/'            => 'home';
+get '/new-clothes' => 'new-clothes';
 
 get '/tag' => sub {
     my $self = shift;

--- a/templates/home.html.haml
+++ b/templates/home.html.haml
@@ -18,37 +18,37 @@
 
 %div
   %span
-    %a#clothes-status-all= sprintf "전체보기 (%d)", $status->{all};
+    %a#clothes-status-all 전체보기
   %span= '|'
   %span
-    %a#clothes-status-1= sprintf " 대여가능 (%d)", $status->{1};
+    %a#clothes-status-1 대여가능
   %span= '|'
   %span
-    %a#clothes-status-2= sprintf " 대여중 (%d)", $status->{2};
+    %a#clothes-status-2 대여중
   %span= '|'
   %span
-    %a#clothes-status-3= sprintf " 대여불가 (%d)", $status->{3};
+    %a#clothes-status-3 대여불가
   %span= '|'
   %span
-    %a#clothes-status-4= sprintf " 예약 (%d)", $status->{4};
+    %a#clothes-status-4 예약
   %span= '|'
   %span
-    %a#clothes-status-5= sprintf " 세탁 (%d)", $status->{5};
+    %a#clothes-status-5 세탁
   %span= '|'
   %span
-    %a#clothes-status-6= sprintf " 수선 (%d)", $status->{6};
+    %a#clothes-status-6 수선
   %span= '|'
   %span
-    %a#clothes-status-7= sprintf " 분실 (%d)", $status->{7};
+    %a#clothes-status-7 분실
   %span= '|'
   %span
-    %a#clothes-status-8= sprintf " 폐기 (%d)", $status->{8};
+    %a#clothes-status-8 폐기
   %span= '|'
   %span
-    %a#clothes-status-9= sprintf " 반납 (%d)", $status->{9};
+    %a#clothes-status-9 반납
   %span= '|'
   %span
-    %a#clothes-status-11= sprintf " 반납배송중 (%d)", $status->{11};
+    %a#clothes-status-11 반납배송중
 
 .space-4
 


### PR DESCRIPTION
#90 항목의 PR 입니다. 첫 페이지는 선택한 의류의 상태를 변경하기 위한 페이지이기 때문에 전체 항목 또는 상태별 전체 개수는 의미가 없습니다. 관련해서는 #117 항목에서 별도의 페이지로 분리해 처리하기로 했기 때문에 기존에 추가했던 상태별 개수 표시는 제거합니다.
