### PR TITLE
Allow only english for clothes code input form

### DIFF
--- a/templates/home.html.haml
+++ b/templates/home.html.haml
@@ -6,7 +6,7 @@
 .search
   %form#clothes-search-form
     .input-group
-      %input#clothes-id.form-control{ :type => 'text', :placeholder => '의류 코드' }
+      %input#clothes-id.form-control{ :type => 'text', :placeholder => '의류 코드', :style => 'ime-mode:disabled' }
       %span.input-group-btn
         %button#btn-clothes-search.btn.btn-sm.btn-default{ :type => 'button' }
           %i.icon-search.bigger-110 검색

--- a/templates/new-clothes.html.haml
+++ b/templates/new-clothes.html.haml
@@ -185,7 +185,7 @@
                   .space-2
 
                   .form-group.has-info
-                    %label.control-label.no-padding-right.col-xs-12.col-sm-3{ :for => 'clothes-code' } 의류 코드:
+                    %label.control-label.no-padding-right.col-xs-12.col-sm-3{ :for => 'clothes-code', :style => 'ime-mode:disabled' } 의류 코드:
                     .col-xs-12.col-sm-9
                       .clearfix
                         %input#clothes-code.valid.col-xs-12.col-sm-6{ :name => 'clothes-code', :type => 'text' }

--- a/templates/rental.html.haml
+++ b/templates/rental.html.haml
@@ -9,7 +9,7 @@
 .search
   %form#search-form
     .input-group
-      %input#clothes-id.form-control{ :type => 'text', :placeholder => '의류 코드' }
+      %input#clothes-id.form-control{ :type => 'text', :placeholder => '의류 코드', :style => 'ime-mode:disabled' }
       %span.input-group-btn
         %button#btn-search.btn.btn-sm.btn-default{ :type => 'button' }
           %i.icon-search.bigger-110 검색


### PR DESCRIPTION
바코드 입력 양식은 현재 사용자 컴퓨터의 입력기 모드가 무엇이든
간에 영어여야합니다. 그렇지 않으면 바코드 입력기가 스캔을 한 후
바코드 내역을 한글로 뿌려주게 됩니다. 이 문제를 방지하려면
해당 의류 품번 입력창에서 ime-mode 스타일을 이용해 자동으로
입력기가 영어로 설정되도록 해야 합니다.

https://developer.mozilla.org/en-US/docs/Web/CSS/ime-mode
