### PR TITLE
Add opencloset official homepage link (#200)

### DIFF
--- a/templates/visit-box.html.ep
+++ b/templates/visit-box.html.ep
@@ -154,6 +154,16 @@
                           </div>
                         </fieldset>
                       </form>
+
+                      <div class="space-6"></div>
+
+                      <div class="clearfix">
+                        <a class="width-100 pull-right btn btn-sm btn-yellow" href="https://www.theopencloset.net">
+                          <i class="icon-home"></i>
+                          <span> 열린옷장 홈페이지로 돌아가기 </span>
+                        </a>
+                      </div>
+
                     </div>
                   </div><!-- /widget-body -->
                 </div><!-- /visit-box -->

--- a/templates/visit-info-box.html.ep
+++ b/templates/visit-info-box.html.ep
@@ -179,6 +179,16 @@
 
                         </fieldset>
                       </form>
+
+                      <div class="space-6"></div>
+
+                      <div class="clearfix">
+                        <a class="width-100 pull-right btn btn-sm btn-yellow" href="https://www.theopencloset.net">
+                          <i class="icon-home"></i>
+                          <span> 열린옷장 홈페이지로 돌아가기 </span>
+                        </a>
+                      </div>
+
                     </div>
                   </div><!-- /widget-body -->
                 </div><!-- /visit-info-box -->


### PR DESCRIPTION
방문 예약 페이지 중 일반 사용자에게 보이는 모든 곳에 공식 홈페이지로 돌아갈 수 있는 링크를 추가했습니다. 원래는 로그인 박스 아래쪽 가운데에 보이게 하려고했으나 CSS 기술의 부족으로 결국 포기하고 버튼을 추가하는 방식으로 처리했습니다. relative div 하부에 로그인 박스가 absolute로 설정되어 있는데 이 경우 다른 요소를 그 아래쪽에 배치하는 것이 만만하지 않습니다. 좋은 방법있으면 patch welcome 입니다.
