### PR TITLE
Feature/#191 booking by staff

### DIFF
--- a/templates/order-id.html.haml
+++ b/templates/order-id.html.haml
@@ -195,6 +195,11 @@
                                   %li.row
                                     .col-sm-1
                                       %i.icon-caret-right.green
+                                    .col-sm-3.no-padding-left 방문 예약일:
+                                    .col-sm-8=                $order->booking->date->strftime('%Y-%m-%d %H:%M');
+                                  %li.row
+                                    .col-sm-1
+                                      %i.icon-caret-right.green
                                     .col-sm-3.no-padding-left 반납 희망일:
                                     .col-sm-8
                                       :plain


### PR DESCRIPTION
- 주문서에는 반드시 사용자 정보가 들어가야 하므로 템플릿 내의 불필요한 분기문을 제거
- 주문서에 사용자의 방문 예약 시각을 표시
