### PR TITLE
Re-order user profile item again (#246)

### DIFF
--- a/templates/user-id.html.haml
+++ b/templates/user-id.html.haml
@@ -170,6 +170,16 @@
                                   %span.editable#user-bust{ 'data-name' => 'bust' }= $user->user_info->bust
 
                               .profile-info-row
+                                .profile-info-name 허리 둘레
+                                .profile-info-value
+                                  %span.editable#user-waist{ 'data-name' => 'waist' }= $user->user_info->waist
+
+                              .profile-info-row
+                                .profile-info-name 배 둘레
+                                .profile-info-value
+                                  %span.editable#user-belly{ 'data-name' => 'belly' }= $user->user_info->belly
+
+                              .profile-info-row
                                 .profile-info-name 팔 길이
                                 .profile-info-value
                                   %span.editable#user-arm{ 'data-name' => 'arm' }= $user->user_info->arm
@@ -185,24 +195,14 @@
                                   %span.editable#user-knee{ 'data-name' => 'knee' }= $user->user_info->knee
 
                               .profile-info-row
-                                .profile-info-name 배 둘레
+                                .profile-info-name 엉덩이 둘레
                                 .profile-info-value
-                                  %span.editable#user-belly{ 'data-name' => 'belly' }= $user->user_info->belly
-
-                              .profile-info-row
-                                .profile-info-name 허리 둘레
-                                .profile-info-value
-                                  %span.editable#user-waist{ 'data-name' => 'waist' }= $user->user_info->waist
+                                  %span.editable#user-hip{ 'data-name' => 'hip' }= $user->user_info->hip
 
                               .profile-info-row
                                 .profile-info-name 허벅지 둘레
                                 .profile-info-value
                                   %span.editable#user-thigh{ 'data-name' => 'thigh' }= $user->user_info->thigh
-
-                              .profile-info-row
-                                .profile-info-name 엉덩이 둘레
-                                .profile-info-value
-                                  %span.editable#user-hip{ 'data-name' => 'hip' }= $user->user_info->hip
 
                               .profile-info-row
                                 .profile-info-name 발 크기


### PR DESCRIPTION
재변경입니다. :)

신체 치수 잴 때의 업무 효율을 위해 사용자 프로필에서
신체 치수를 다음 순서로 재배치합니다.
- 키
- 몸무게
- 가슴 둘레
- 허리 둘레
- 배 둘레
- 팔 길이
- 다리 길이
- 무릎 길이
- 엉덩이 둘레
- 허벅지 둘레
- 발 크기
