### PR TITLE
Feature/#322 error part return

### DIFF
--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -1896,6 +1896,7 @@ group {
         $order_params{target_date}      = $order->target_date;
         $order_params{user_id}          = $order->user_id;
         $order_params{user_target_date} = $order->user_target_date;
+        $order_params{booking_id}       = $order->booking_id;
         $order_params{status_id}        = 19; # 결제대기
 
         delete $order_params{id};


### PR DESCRIPTION
- `flatten_order()` 메소드에서 `status` 값의 존재 유무 점검 후 `status_name` 값을 할당
- 기존 주문서 반납 후 새로운 주문서 생성 시 기존 주문서의 `booking_id` 정보를 복제
- 기존 주문서 반납 후 새로운 주문서 생성시 새로운 주문서의 상태를 _결제대기_로 강제 설정
