### PR TITLE
Set case insensitive when return the order (#313)

### DIFF
--- a/coffee/order-id.coffee
+++ b/coffee/order-id.coffee
@@ -414,7 +414,7 @@ $ ->
   # 검색한 의류 품번에 일치하는 주문서 목록의 체크박스에 체크
   #
   selectSearchedClothes = ->
-    clothes_code = OpenCloset.trimClothesCode $('#clothes-search').val()
+    clothes_code = OpenCloset.trimClothesCode $('#clothes-search').val().toUpperCase()
     $('#clothes-search').val('').focus()
     $(".return-process input[data-clothes-code=#{ clothes_code }]").click()
     refreshReturnButton()


### PR DESCRIPTION
반납 진행시 의류 품번을 입력할 때 대소문자 구분없이 입력을 받아 강제로 대문자로 처리하도록 수정합니다. 이로써 키보드의 상태가 대문자이든 소문자이든 상관없이 바코드 리더기를 이용해 반납 절차를 진행할 수 있습니다.
