### PR TITLE
Monitor/post event

### DIFF
--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -512,6 +512,14 @@ helper update_user => sub {
         });
 
         $guard->commit;
+
+        #
+        # event posting to opencloset/monitor
+        #
+        my $res = HTTP::Tiny->new(timeout => 1)->post_form(app->config->{monitor_uri} . '/events', {
+            sender  => 'user',
+            user_id => $user->id
+        });
     }
 
     return $user;


### PR DESCRIPTION
https://github.com/opencloset/monitor/issues/18

이슈 해결을 위한 PR 입니다.

주문서 뿐만 아니라 사용자 정보가 바뀌었을때에도 monitor 에 이벤트를
전달해야 합니다.
