### PR TITLE
Add button to set back order status as '포장' (#328)

### DIFF
--- a/coffee/order-id.coffee
+++ b/coffee/order-id.coffee
@@ -160,6 +160,15 @@ $ ->
     display: (value, sourceData, response) -> $(this).html( OpenCloset.commify value )
     success: (response, newValue) -> updateOrder()
 
+  $('#btn-order-clear').click (e) ->
+    order_id = $('#order').data('order-id')
+    $.ajax "/api/order/#{ order_id }/set-package.json",
+      type: 'GET'
+      success: (data, textStatus, jqXHR) ->
+      error: (jqXHR, textStatus, errorThrown) ->
+      complete: (jqXHR, textStatus) ->
+        window.location.assign "/order?status=19"
+
   $('#btn-order-confirm').click (e) ->
     order_id     = $('#order').data('order-id')
     url          = $(e.target).data('url')

--- a/templates/order-id.html.haml
+++ b/templates/order-id.html.haml
@@ -468,6 +468,9 @@
                           %a#btn-order-confirm.btn.btn-info.pull-right{ :type => 'button', :href => "#", 'data-url' => "#{ url_for('/order/' . $order->id . '/update') }", 'data-redirect-url' => "#{ url_for('/order/' . $order->id) }", 'data-monitor-url' => "#{$monitor_uri}/events" }
                             %i.icon-ok.bigger-110
                             주문 확정
+                          %a#btn-order-clear.btn.btn-danger.pull-right{ :type => 'button', :href => "#" }
+                            %i.icon-remove.bigger-110
+                            새로 주문
                       -   }
                       - }
                 :plain


### PR DESCRIPTION
결제 대기 상태에서 포장 상태로 되돌릴 수 있는 버튼을
각각의 주문서 페이지에 추가합니다. 이 버튼을 이용하면
포장 상태에서 추가한 항목과 에누리, 배송비 등의 항목이
모두 제거되며 더불어 담당자와 대여 기간, 대여일 등
주문서에서 좌측 항목에서 보이는 모든 항목이 초기화 됩니다.
