### PR TITLE
#318 order status log

### DIFF
--- a/db/schema-loader.pl
+++ b/db/schema-loader.pl
@@ -73,6 +73,12 @@ my $CONF = OpenCloset::Util::load_config('app.conf');
                         encode_check_method => 'check_password',
                     };
                 }
+                when ('timestamp') {
+                    return +{
+                        %$col_info,
+                        inflate_datetime => 1,
+                    };
+                }
             }
 
             return;

--- a/lib/OpenCloset/Schema/Result/Order.pm
+++ b/lib/OpenCloset/Schema/Result/Order.pm
@@ -416,6 +416,21 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 order_status_logs
+
+Type: has_many
+
+Related object: L<OpenCloset::Schema::Result::OrderStatusLog>
+
+=cut
+
+__PACKAGE__->has_many(
+  "order_status_logs",
+  "OpenCloset::Schema::Result::OrderStatusLog",
+  { "foreign.order_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 orders
 
 Type: has_many
@@ -507,8 +522,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07042 @ 2014-12-09 04:39:58
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hSNicdrSyKTNv9djlu0n/g
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-05 14:39:12
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:gXjgU8IR5eI0B0MfYUVfyw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/OrderStatusLog.pm
+++ b/lib/OpenCloset/Schema/Result/OrderStatusLog.pm
@@ -1,0 +1,127 @@
+use utf8;
+package OpenCloset::Schema::Result::OrderStatusLog;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+OpenCloset::Schema::Result::OrderStatusLog
+
+=cut
+
+use strict;
+use warnings;
+
+=head1 BASE CLASS: L<OpenCloset::Schema::Base>
+
+=cut
+
+use base 'OpenCloset::Schema::Base';
+
+=head1 TABLE: C<order_status_log>
+
+=cut
+
+__PACKAGE__->table("order_status_log");
+
+=head1 ACCESSORS
+
+=head2 order_id
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_foreign_key: 1
+  is_nullable: 0
+
+=head2 status_id
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_foreign_key: 1
+  is_nullable: 0
+
+=head2 timestamp
+
+  data_type: 'datetime'
+  datetime_undef_if_invalid: 1
+  is_nullable: 0
+
+=cut
+
+__PACKAGE__->add_columns(
+  "order_id",
+  {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_foreign_key => 1,
+    is_nullable => 0,
+  },
+  "status_id",
+  {
+    data_type => "integer",
+    extra => { unsigned => 1 },
+    is_foreign_key => 1,
+    is_nullable => 0,
+  },
+  "timestamp",
+  {
+    data_type => "datetime",
+    datetime_undef_if_invalid => 1,
+    is_nullable => 0,
+  },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</order_id>
+
+=item * L</status_id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("order_id", "status_id");
+
+=head1 RELATIONS
+
+=head2 order
+
+Type: belongs_to
+
+Related object: L<OpenCloset::Schema::Result::Order>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "order",
+  "OpenCloset::Schema::Result::Order",
+  { id => "order_id" },
+  { is_deferrable => 1, on_delete => "RESTRICT", on_update => "RESTRICT" },
+);
+
+=head2 status
+
+Type: belongs_to
+
+Related object: L<OpenCloset::Schema::Result::Status>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "status",
+  "OpenCloset::Schema::Result::Status",
+  { id => "status_id" },
+  { is_deferrable => 1, on_delete => "RESTRICT", on_update => "RESTRICT" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-05 14:39:12
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:KiDFxd0uFRd+ToRtI0Kcdg
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/lib/OpenCloset/Schema/Result/OrderStatusLog.pm
+++ b/lib/OpenCloset/Schema/Result/OrderStatusLog.pm
@@ -45,6 +45,7 @@ __PACKAGE__->table("order_status_log");
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
+  inflate_datetime: 1
   is_nullable: 0
 
 =cut
@@ -68,6 +69,7 @@ __PACKAGE__->add_columns(
   {
     data_type => "datetime",
     datetime_undef_if_invalid => 1,
+    inflate_datetime => 1,
     is_nullable => 0,
   },
 );
@@ -119,8 +121,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-05 14:39:12
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:KiDFxd0uFRd+ToRtI0Kcdg
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-05 17:12:39
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Yyz59C3TJnn30W91s5QoOQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/OpenCloset/Schema/Result/Status.pm
+++ b/lib/OpenCloset/Schema/Result/Status.pm
@@ -112,6 +112,21 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 order_status_logs
+
+Type: has_many
+
+Related object: L<OpenCloset::Schema::Result::OrderStatusLog>
+
+=cut
+
+__PACKAGE__->has_many(
+  "order_status_logs",
+  "OpenCloset::Schema::Result::OrderStatusLog",
+  { "foreign.status_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 orders
 
 Type: has_many
@@ -128,8 +143,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07038 @ 2014-01-24 15:02:06
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:eAvl6lAiIfh5Zk2QfXHXAQ
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-05 14:39:12
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hal2Tui8Ets0LPkE/ujaFA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration


### PR DESCRIPTION
사용자의 상태별 경과시간을 저장해두기 위한 통계 테이블을 추가하였습니다.
MySQL 의 trigger 기능을 이용해서 상태가 변경되거나 주문서가 추가되면 데이터가 쌓이게 됩니다.

실서버의 DB 버전을 확인하고 지원가능하다면 바로 적용해도 되겠습니다.

단,

create table, create trigger 쿼리를 통해 만들어주어야 합니다.