### PR TITLE
Feature/#315 order add compensation pay with2

### DIFF
--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -248,10 +248,14 @@ helper flatten_order => sub {
     return unless $order;
 
     my $order_price        = 0;
-    my $order_stage0_price = 0;
+    my %order_stage_price = (
+        0 => 0,
+        1 => 0,
+        2 => 0,
+    );
     for my $order_detail ( $order->order_details ) {
-        $order_price        += $order_detail->final_price;
-        $order_stage0_price += $order_detail->final_price if $order_detail->stage == 0;
+        $order_price                               += $order_detail->final_price;
+        $order_stage_price{ $order_detail->stage } += $order_detail->final_price;
     }
 
     my %data = (
@@ -262,7 +266,7 @@ helper flatten_order => sub {
         user_target_date => undef,
         return_date      => undef,
         price            => $order_price,
-        stage0_price     => $order_stage0_price,
+        stage_price      => \%order_stage_price,
         clothes_price    => $self->order_clothes_price($order),
         clothes          => [ $order->order_details({ clothes_code => { '!=' => undef } })->get_column('clothes_code')->all ],
         late_fee         => $self->calc_late_fee($order),
@@ -1701,6 +1705,7 @@ group {
             belly
             bestfit
             bust
+            compensation_pay_with
             desc
             foot
             height
@@ -1776,6 +1781,7 @@ group {
             belly
             bestfit
             bust
+            compensation_pay_with
             desc
             foot
             height

--- a/db/init.sql
+++ b/db/init.sql
@@ -309,44 +309,45 @@ CREATE TABLE `booking` (
 --
 
 CREATE TABLE `order` (
-  `id`                INT UNSIGNED NOT NULL AUTO_INCREMENT,
-  `user_id`           INT UNSIGNED NOT NULL,
-  `status_id`         INT UNSIGNED DEFAULT NULL,
-  `staff_id`          INT UNSIGNED DEFAULT NULL,
-  `parent_id`         INT UNSIGNED DEFAULT NULL,
-  `booking_id`        INT UNSIGNED DEFAULT NULL,
+  `id`                    INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id`               INT UNSIGNED NOT NULL,
+  `status_id`             INT UNSIGNED DEFAULT NULL,
+  `staff_id`              INT UNSIGNED DEFAULT NULL,
+  `parent_id`             INT UNSIGNED DEFAULT NULL,
+  `booking_id`            INT UNSIGNED DEFAULT NULL,
 
-  `additional_day`    INT UNSIGNED DEFAULT 0,
-  `rental_date`       DATETIME DEFAULT NULL,
-  `target_date`       DATETIME DEFAULT NULL,
-  `user_target_date`  DATETIME DEFAULT NULL,
-  `return_date`       DATETIME DEFAULT NULL,
-  `return_method`     VARCHAR(32) DEFAULT NULL,
-  `price_pay_with`    VARCHAR(32) DEFAULT NULL,
-  `late_fee_pay_with` VARCHAR(32) DEFAULT NULL,
-  `desc`              TEXT DEFAULT NULL,
+  `additional_day`        INT UNSIGNED DEFAULT 0,
+  `rental_date`           DATETIME DEFAULT NULL,
+  `target_date`           DATETIME DEFAULT NULL,
+  `user_target_date`      DATETIME DEFAULT NULL,
+  `return_date`           DATETIME DEFAULT NULL,
+  `return_method`         VARCHAR(32) DEFAULT NULL,
+  `price_pay_with`        VARCHAR(32) DEFAULT NULL,
+  `late_fee_pay_with`     VARCHAR(32) DEFAULT NULL,
+  `compensation_pay_with` VARCHAR(32) DEFAULT NULL,
+  `desc`                  TEXT DEFAULT NULL,
 
 
   -- guest info
-  `purpose`           VARCHAR(128) DEFAULT NULL,
-  `purpose2`          TEXT DEFAULT NULL,
-  `pre_category`      VARCHAR(128) DEFAULT NULL,
-  `pre_color`         VARCHAR(32)  DEFAULT NULL,
-  `height`            INT DEFAULT NULL, -- 키(cm)
-  `weight`            INT DEFAULT NULL, -- 몸무게(kg)
-  `bust`              INT DEFAULT NULL, -- 가슴   둘레(cm)
-  `waist`             INT DEFAULT NULL, -- 허리   둘레(cm)
-  `hip`               INT DEFAULT NULL, -- 엉덩이 둘레(cm)
-  `belly`             INT DEFAULT NULL, -- 배     둘레(cm)
-  `thigh`             INT DEFAULT NULL, -- 허벅지 둘레(cm)
-  `arm`               INT DEFAULT NULL, -- 팔     길이(cm)
-  `leg`               INT DEFAULT NULL, -- 다리   길이(cm)
-  `knee`              INT DEFAULT NULL, -- 무릎   길이(cm)
-  `foot`              INT DEFAULT NULL, -- 발 크기(mm)
-  `bestfit`           BOOLEAN DEFAULT 0,
+  `purpose`               VARCHAR(128) DEFAULT NULL,
+  `purpose2`              TEXT DEFAULT NULL,
+  `pre_category`          VARCHAR(128) DEFAULT NULL,
+  `pre_color`             VARCHAR(32)  DEFAULT NULL,
+  `height`                INT DEFAULT NULL, -- 키(cm)
+  `weight`                INT DEFAULT NULL, -- 몸무게(kg)
+  `bust`                  INT DEFAULT NULL, -- 가슴   둘레(cm)
+  `waist`                 INT DEFAULT NULL, -- 허리   둘레(cm)
+  `hip`                   INT DEFAULT NULL, -- 엉덩이 둘레(cm)
+  `belly`                 INT DEFAULT NULL, -- 배     둘레(cm)
+  `thigh`                 INT DEFAULT NULL, -- 허벅지 둘레(cm)
+  `arm`                   INT DEFAULT NULL, -- 팔     길이(cm)
+  `leg`                   INT DEFAULT NULL, -- 다리   길이(cm)
+  `knee`                  INT DEFAULT NULL, -- 무릎   길이(cm)
+  `foot`                  INT DEFAULT NULL, -- 발 크기(mm)
+  `bestfit`               BOOLEAN DEFAULT 0,
 
-  `create_date`      DATETIME DEFAULT NULL,
-  `update_date`      DATETIME DEFAULT NULL,
+  `create_date`           DATETIME DEFAULT NULL,
+  `update_date`           DATETIME DEFAULT NULL,
 
   PRIMARY KEY (`id`),
   CONSTRAINT `fk_order1` FOREIGN KEY (`user_id`)    REFERENCES `user`    (`id`) ON DELETE CASCADE,

--- a/lib/OpenCloset/Schema/Result/Order.pm
+++ b/lib/OpenCloset/Schema/Result/Order.pm
@@ -122,6 +122,12 @@ __PACKAGE__->table("order");
   is_nullable: 1
   size: 32
 
+=head2 compensation_pay_with
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 32
+
 =head2 desc
 
   data_type: 'text'
@@ -313,6 +319,8 @@ __PACKAGE__->add_columns(
   "price_pay_with",
   { data_type => "varchar", is_nullable => 1, size => 32 },
   "late_fee_pay_with",
+  { data_type => "varchar", is_nullable => 1, size => 32 },
+  "compensation_pay_with",
   { data_type => "varchar", is_nullable => 1, size => 32 },
   "desc",
   { data_type => "text", is_nullable => 1 },
@@ -522,8 +530,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-05 14:39:12
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:gXjgU8IR5eI0B0MfYUVfyw
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-01-06 20:46:07
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:dzmxr2CsGq+f9MqpSd5LUg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/templates/order-id.html.haml
+++ b/templates/order-id.html.haml
@@ -204,6 +204,65 @@
                                         >#{ $order->late_fee_pay_with || q{미납} }</a>
                                       \/
                                       %strong.late-fee-final 0원
+                                  %li.row.return-process
+                                    .col-sm-1
+                                      %i.icon-caret-right.blue
+                                    .col-sm-3.no-padding-left 배상비:
+                                    .col-sm-8
+                                      :plain
+                                        <a
+                                          id               = "order-compensation"
+                                          class            = "editable editable-click"
+                                          href             = "#"
+
+                                          data-disabled    = "true"
+                                          data-mode        = "inline"
+                                          data-showbuttons = "true"
+                                          data-type        = "text"
+                                          data-emptytext   = "0"
+
+                                          data-value       = "0"
+                                        ></a>원
+                                  %li.row.return-process
+                                    .col-sm-1
+                                      %i.icon-caret-right.blue
+                                    .col-sm-3.no-padding-left 배상비 에누리:
+                                    .col-sm-8
+                                      :plain
+                                        <a
+                                          id               = "order-compensation-discount"
+                                          class            = "editable editable-click"
+                                          href             = "#"
+
+                                          data-disabled    = "true"
+                                          data-mode        = "inline"
+                                          data-showbuttons = "true"
+                                          data-type        = "text"
+                                          data-emptytext   = "0"
+
+                                          data-value       = "0"
+                                        ></a>원
+                                  %li.row
+                                    .col-sm-1
+                                      %i.icon-caret-right.blue
+                                    .col-sm-3.no-padding-left 최종 배상비:
+                                    .col-sm-8
+                                      :plain
+                                        <a
+                                          id               = "order-compensation-pay-with"
+                                          class            = "editable editable-click"
+                                          href             = "#"
+
+                                          data-disabled    = "true"
+                                          data-mode        = "inline"
+                                          data-showbuttons = "true"
+                                          data-type        = "select"
+                                          data-emptytext   = "미납"
+
+                                          data-value       = "#{ $order->compensation_pay_with || q{} }"
+                                        >#{ $order->compensation_pay_with || q{미납} }</a>
+                                      \/
+                                      %strong.compensation-final 0원
                             /
                             / 대여자 정보
                             /


### PR DESCRIPTION
배상비를 입력할 수 있도록 구현했습니다.

- `order.compensation_pay_with` 컬럼 추가
- DBIC 라이브러리 갱신
- 부분 반납이 아닌 전체 반납일 경우에 한해서 배상비 입력이 가능하도록 함
- 최종 연체료는 `order_detail`의 `stage`가 1인 항목의 총합으로 계산함
- 최종 배상비는 `order_detail`의 `stage`가 2인 항목의 총합으로 계산함