### PR TITLE
#334 catch address search exception

### DIFF
--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -3803,7 +3803,15 @@ group {
         my $self   = shift;
         my $q      = $self->param('q');
         my $p      = Postcodify->new( config => $ENV{MOJO_CONFIG} || './app.psgi.conf' );
-        my $result = $p->search( $q );
+        my $result = try { $p->search( $q ) } catch {
+            $self->app->log->error("api_postcode_search failed: $q");
+        };
+
+        unless ($result) {
+            $self->error(500, {str => "api_postcode_search failed: $q"});
+            return;
+        }
+
         $self->render(text => decode_utf8($result->json), format => 'json');
     }
 

--- a/coffee/visit.coffee
+++ b/coffee/visit.coffee
@@ -497,7 +497,7 @@ $ ->
   # 주소검색
   #
   $("#postcodify").postcodify
-    api: "/api/postcode/search"
+    api: "/api/postcode/search.json"
     timeout: 10000    # 10 seconds
     insertDbid : ".postcodify_dbid"
     insertAddress : ".postcodify_address"

--- a/coffee/visit2.coffee
+++ b/coffee/visit2.coffee
@@ -375,7 +375,7 @@ $ ->
   # 주소검색
   #
   $("#postcodify").postcodify
-    api: "/api/postcode/search"
+    api: "/api/postcode/search.json"
     timeout: 10000    # 10 seconds
     insertDbid : ".postcodify_dbid"
     insertAddress : ".postcodify_address"


### PR DESCRIPTION
#334 

서버에서 오류를 발견하면 즉각 에러를 응답하도록 해서 행걸린듯한 현상을 줄이려고 하였습니다.
궁극적으로는 postcodify 에서 수정되는게 좋겠지만, 어떤 쿼리가 들어왔을때에 오류가 발생하는지 몰라서
일단 추적하도록 하겠습니다.

추적되고 나면 postcodify 에서 수정 후 버전을 올려서 사용하도록 하면 되겠습니다.

서버에서는 `grunt` 해주어야 합니다.