### PR TITLE
Fix IE11 bug when selecting booking time

### DIFF
--- a/templates/visit-info-box.html.ep
+++ b/templates/visit-info-box.html.ep
@@ -303,7 +303,7 @@
                     <%% var ymd = dt.format('YYYY-MM-DD'); %>
                     <%% var hm  = dt.format('HH:mm'); %>
                     <td class="center">
-                      <input class="ace" type="radio" name="booking_id" value="<%%= id %>" data-id="<%%= id %>" data-ymd="<%%= ymd %>" data-hm="<%%= hm %>">
+                      <input type="radio" name="booking_id" value="<%%= id %>" data-id="<%%= id %>" data-ymd="<%%= ymd %>" data-hm="<%%= hm %>">
                       <span class="lbl"></span>
                     </td>
                     <td> <%%= ymd %> </td>


### PR DESCRIPTION
IE11 이상으로 접근 시 현재 열린옷장 방문 예약 페이지 접근이 가능합니다. 그런데 다른 기능은 다 정상 동작하나 방문 예약 일시 선택 시점에 라디오 버튼을 클릭할 수 없는 현상이 존재합니다.  디버깅을 통해 확인해보니 ace 테마가 사용하는 CSS대로라면 IE에서는 라디오 버튼이 눈으로 보이는 것보다 앞에 위치하는 것으로 인지해 클릭이 불가능한 현상이었습니다.  이것이 이상한 것이 다른 페이지에선 상관이 없으나 유독 모달로 띄워 동적으로 생성한 테이블 안의 라디오 버튼일 경우 오동작합니다.  어쨌든 ace 테마의 css를 사용하지 않을 경우 문제없이 클릭이 되는 것을 확인했습니다. 따라서 라디오 버튼의 CSS에서 ace 테마 적용 부분을 제거했으며 이 경우 IE11에서 정상 동작하며 예약에 문제가 없음을 확인 했습니다.
