### PR TITLE
Add user link in recent order list (#356)

### DIFF
--- a/templates/clothes-code.html.haml
+++ b/templates/clothes-code.html.haml
@@ -182,7 +182,7 @@
                                 .profile-activity.clearfix
                                   %div
                                     %img.pull-left{ :alt => "#{ $order->user->name }'s avatar", :src => '#{ get_gravatar( $order->user, 36, https => 1 ) }' }
-                                    = $order->user->name
+                                    %a{ :href => "#{ url_for( '/user/' . $order->user->id ) }" }= $order->user->name
                                     %a.order-badge{ :href => "/order/#{ $order->id }" }
                                       %span.label.label-info.arrowed-right.arrowed-in
                                         %strong 주문서

--- a/templates/user-id.html.haml
+++ b/templates/user-id.html.haml
@@ -230,8 +230,8 @@
                               -   my $late_fee = calc_late_fee($order);
                                 .profile-activity.clearfix
                                   %div
-                                    %img.pull-left{ :alt => "#{ $user->name }'s avatar", :src => '#{ get_gravatar( $user, 36, https => 1 ) }' }
-                                    = $user->name
+                                    %img.pull-left{ :alt => "#{ $order->user->name }'s avatar", :src => '#{ get_gravatar( $order->user, 36, https => 1 ) }' }
+                                    %a{ :href => "#{ url_for( '/user/' . $order->user->id ) }" }= $order->user->name
                                     %a.order-badge{ :href => "/order/#{ $order->id }" }
                                       - if ( $order->rental_date && $order->target_date ) {
                                         %span.label.label-info.arrowed-right.arrowed-in


### PR DESCRIPTION
사용자 정보와 의류 정보 페이지의 최근 주문 내역에서 표시하는 주문서 정보 중 사용자 이름에 사용자의 링크를 추가해서 옷장지기가 조금 더 편리하게 사용자 정보에 접근할 수 있도록 수정합니다.