### PR TITLE
Round average body measuremnt size (#359)

### DIFF
--- a/templates/clothes-code.html.haml
+++ b/templates/clothes-code.html.haml
@@ -50,6 +50,7 @@
                       .hr.hr16.dotted
 
                       %div
+                        - map { $average_size->{$_} = sprintf "%.1f", $average_size->{$_} } keys %$average_size;
                         %span.label.label-success= $average_size->{height} || '-'
                         %span.label.label-success= $average_size->{weight} || '-'
                         %br


### PR DESCRIPTION
의류 정보의 좌측에 표시하는 해당 의류를 대여한 전체 사용자의 신체 치수의 평균을 보여줄 때 소숫점 둘째 자리에서 반올림해 첫째 자리까지만 보여주도록 수정합니다.