### PR TITLE
Display clothes status (#358)

### DIFF
--- a/templates/clothes-code.html.haml
+++ b/templates/clothes-code.html.haml
@@ -92,6 +92,11 @@
                                   %span.clothes-code#clothes-code= $clothes_code
 
                               .profile-info-row
+                                .profile-info-name 상태
+                                .profile-info-value
+                                  %span#clothes-status_id= $clothes->status->name
+
+                              .profile-info-row
                                 .profile-info-name 종류
                                 .profile-info-value
                                   %span.editable#clothes-category{ 'data-name' => 'category', 'data-value' => "#{ $clothes->category }" }


### PR DESCRIPTION
의류 정보 페이지에서 의류의 현재 상태를 열람할 수 있도록 합니다. 직원의 실수를 방지하기 위해 상태 수정 기능은 없이 열람만 가능하도록 합니다.