### PR TITLE
Add purpose & purpose2 in each order page (#379)

### DIFF
--- a/templates/order-id.html.haml
+++ b/templates/order-id.html.haml
@@ -281,6 +281,16 @@
                                   %li.row
                                     .col-sm-1
                                       %i.icon-caret-right.green
+                                    .col-sm-3.no-padding-left 대여 목적:
+                                    .col-sm-8=                $order->purpose
+                                  %li.row
+                                    .col-sm-1
+                                      %i.icon-caret-right.green
+                                    .col-sm-3.no-padding-left 상세 대여 목적:
+                                    .col-sm-8=                $order->purpose2
+                                  %li.row
+                                    .col-sm-1
+                                      %i.icon-caret-right.green
                                     .col-sm-3.no-padding-left 방문 예약일:
                                     .col-sm-8
                                       - if ( $order->booking ) {


### PR DESCRIPTION
각각의 주문서의 대여자 정보란에 방문 예약시 입력했던 대여 목적과 상세 대여 목적을 표시해서 옷장지기가 더욱 수월하게 손님을 응대할 수 있도록 합니다.