### PR TITLE
Allow add donation without new clothes (#211)

### DIFF
--- a/coffee/new-clothes.coffee
+++ b/coffee/new-clothes.coffee
@@ -240,10 +240,18 @@ $ ->
             e.preventDefault()
             return
         when 3
+          ###
+          #
+          # #211 - 개별 옷을 등록하지 않고 기증행위가 등록이 가능해야 함
+          #
+          # 개별 옷 등록 없이 기증행위를 등록할 수 있기를 바라므로 추가할
+          # 의류를 선택했는지 여부를 확인하는 코드를 주석 처리합니다.
+          #
           unless $("input[name=clothes-list]:checked").length
             OpenCloset.alert('warning', '추가할 의류를 선택하지 않았습니다.')
             e.preventDefault()
             return
+          ###
 
           #
           # FIXME do we need a single API for transaction?


### PR DESCRIPTION
개별 옷 등록 없이 기증행위를 등록할 수 있어야 하는 이유입니다.

1. 직원의 실수로 여러벌의 옷을 다른 기증행위에 넣었을 때,
   그 중 한가지 개별의류를 빼내어 다른 기증행위에 옮겨야 하는
   경우가 발생할 수 있습니다. 이때 다른 기증행위로 옮기기 위해서는
   빈 기증행위가 등록가능해야 합니다.

2. 기증행위가 없는 메세지가 존재합니다. 가령 10벌을 기증했으나
   전부다 옷캔으로 재기증되어 실제 프로그램에서는 새옷 등록을
   할 수 없는 경우가 대표적인 예입니다. 기증 메시지를 등록하기
   위해서라도 옷 없이 기증행위를 등록할 수 있어야 합니다.

기존 코드에서 의류를 선택했는지 여부를 확인하는 부분만 동작하지
않도록 주석 처리합니다.