### PR TITLE
Feature/#426 display current sms type

### DIFF
--- a/coffee/bundle.coffee
+++ b/coffee/bundle.coffee
@@ -145,6 +145,21 @@ $ ->
           success_cb( data, textStatus, jqXHR )
         error: (jqXHR, textStatus, errorThrown) ->
           error_cb( jqXHR, textStatus, errorThrown )
+    charScreenWidth: (ch) ->
+      return 0 if ch is null || ch.length == 0
+
+      charCode = ch.charCodeAt(0)
+      return 1 if charCode <= 0x00007F # 1 bytes
+      return 2 if charCode <= 0x0007FF # 2 bytes
+      return 2 if charCode <= 0x00FFFF # 3 bytes
+      return 2
+    strScreenWidth: (str) ->
+      return 0 if str is null || str.length == 0
+
+      size = 0
+      for i in [ 0..str.length ]
+        size += OpenCloset.charScreenWidth( str.charAt(i) )
+      return size
 
   #
   # return nothing

--- a/coffee/sms.coffee
+++ b/coffee/sms.coffee
@@ -10,6 +10,15 @@ $ ->
       text: '전화 요망'
       msg:  '안녕하세요. 열린옷장입니다. 전화부탁드립니다.'
 
+  updateMsgScreenWidth = ->
+    msg   = $('textarea[name=msg]').prop('value')
+    width = OpenCloset.strScreenWidth(msg)
+    $('.msg-screen-width').html(width)
+
+  $('textarea[name=msg]')
+    .on( 'keyup', (e)  -> updateMsgScreenWidth() )
+    .on( 'change', (e) -> updateMsgScreenWidth() )
+
   #
   # dynamic chosen item manupulation
   # http://stackoverflow.com/questions/11352207/jquery-chosen-plugin-add-options-dynamically
@@ -18,6 +27,7 @@ $ ->
   $('select[name=macro]').trigger("liszt:updated")
   $('select[name=macro]').change ->
     $('textarea[name=msg]').prop( 'value', macros[ $(this).prop('value') ].msg )
+    updateMsgScreenWidth()
 
   $('#btn-sms-send').click (e) ->
     to  = $('input[name=to]').prop('value')

--- a/templates/sms.html.haml
+++ b/templates/sms.html.haml
@@ -30,7 +30,12 @@
         .col-sm-9
           %select.col-xs-10.col-sm-5{ :name => "macro", :type => 'hidden', 'data-placeholder' => '전송할 메시지의 종류를 선택하세요.' }
       .form-group
-        %label.col-sm-3.control-label.no-padding-right{ :for => 'msg' } 메시지
+        %label.col-sm-3.control-label.no-padding-right{ :for => 'msg' }
+          메시지
+          %br
+          %span
+            %span.msg-screen-width= '0'
+            = ' / 88'
         .col-sm-9
           %textarea.col-xs-10.col-sm-8{ :name => "msg", :placeholder => "한글 기준 44자가 넘지 않을 경우 SMS로, 넘을 경우 LMS로 전송합니다.", :rows => "5" }= $msg
       .form-actions.clearfix


### PR DESCRIPTION
- 번들 자바스크립트 라이브러리에 문자열의 너비(screen width)를 계산하는 메소드 추가
- 해당 메소드를 이용해서 사용자가 입력한 문자 메시지의 길이를 보여주어 LMS인지 SMS인지 분간 할 수 있도록 함