### PR TITLE
Add pre-defined sms macro link in order list page (#452)

### DIFF
--- a/templates/order.html.haml
+++ b/templates/order.html.haml
@@ -69,6 +69,8 @@
         %th 비고
     %tbody
       - while ( my $order = $order_list->next ) {
+      -   my $overdue  = calc_overdue($order);
+      -   my $late_fee = calc_late_fee($order);
         %tr
           %td.center
             %a{ :href => "#{url_for('/order/' . $order->id)}" }= $order->id
@@ -78,11 +80,21 @@
               - if ( $order->status ) {
               -   $status = $order->status->name;
               -   if ( $status eq '대여중' ) {
-              -     my $late_fee = calc_late_fee($order);
-              -     $status .= '(연체) ' . commify($late_fee) . '원' if $late_fee;
+              -     $status .= '(연체) ' . commify($late_fee) . '원' if $overdue;
               -   }
               - }
               %span.label.order-status{ 'data-order-status' => "#{ $order->status ? $order->status->name : q{} }" }= $status || '상태없음'
+              - if ($overdue) {
+              -   my $sms_str = sprintf(
+              -     '%s님 열린옷장 대여기간이 %d일 연체되었습니다. %s원 입금 부탁드립니다. 국민은행 20570104-269524',
+              -     $order->user->name,
+              -     $overdue,
+              -     commify($late_fee),
+              -   );
+                %br
+                %a{ :href => "#{ url_for('/sms')->query( to => $order->user->user_info->phone, msg => $sms_str ) }" }
+                  연체 문자 전송
+              - }
           %td
             = $order->rental_date ? $order->rental_date->ymd : q{}
           %td


### PR DESCRIPTION
옷장지기와 논의해본 결과 연체자는 연체 목록 화면에서 확인 한 후 사용자 링크를 누르고 다시 SMS 보내기 누르기 과정을 거친 다음 전송할 메시지를 입력한다고 합니다. 따라서 연체 목록 화면에서 바로 해당 주문서 별로 연체 관련 문자 메시지를 보낼 수 있는 링크를 추가하면 담당자의 수고가 몇 배 이상으로 수월해집니다.  이를 위해 주문서 목록에서 연체인 경우에 한해 연체 문자 보내기 링크를 추가합니다.  
