### PR TITLE
Use HTTP basic authentication for external services

### DIFF
--- a/app.conf.sample
+++ b/app.conf.sample
@@ -272,4 +272,7 @@ $db_opts->{AutoCommit} //= 1;
     # monitor
     #
     monitor_uri => 'http://localhost:5000',
+    external_service => {
+        monitor => 'opencloset#s3cr3t'
+    }
 };


### PR DESCRIPTION
#470 

monitor 에서 opencloset 으로 주문서의 상태변경 요청을 할 필요가
있어서 외부서비스에서 간단하게 인증후에 주문서 변경 api 를 호출 할 수
있도록 변경하였습니다.