### PR TITLE
Allow only english for clothes code input form (#468)

### DIFF
--- a/templates/order-id.html.haml
+++ b/templates/order-id.html.haml
@@ -647,7 +647,7 @@
                       -   if ( $order_status eq '대여중' ) {
                         .search.pull-left.return-process
                           .input-group
-                            %input#clothes-search.form-control{ :name => 'clothes-search' :type => 'text', :placeholder => '의류 품번' }
+                            %input#clothes-search.form-control{ :name => 'clothes-search' :type => 'text', :placeholder => '의류 품번', :style => 'ime-mode:disabled' }
                             %span.input-group-btn
                               %button#btn-clothes-search.btn.btn-default.btn-sm{ :type => 'submit' }
                                 %i.icon-search.bigger-110 검색


### PR DESCRIPTION
바코드 입력 양식은 현재 사용자 컴퓨터의 입력기 모드가 무엇이든
간에 영어여야합니다. 그렇지 않으면 바코드 입력기가 스캔을 한 후
바코드 내역을 한글로 뿌려주게 됩니다. 이 문제를 방지하려면
해당 의류 품번 입력창에서 ime-mode 스타일을 이용해 자동으로
입력기가 영어로 설정되도록 해야 합니다.

https://developer.mozilla.org/en-US/docs/Web/CSS/ime-mode

SEE ALSO: 3f1ddc09126c65cbd95fca7d988bfccd46107972