### PR TITLE
Display donation id & username beside clothes code (#473)

### DIFF
--- a/templates/order-id.html.haml
+++ b/templates/order-id.html.haml
@@ -497,7 +497,13 @@
                                     %td.center= ++$count
                                     - if ( $detail->clothes ) {
                                       %td
-                                        %a{ :href => "/clothes/#{ trim_clothes_code($detail->clothes) }" }= $detail->name
+                                        %span
+                                          %a{ :href => "/clothes/#{ trim_clothes_code($detail->clothes) }" }= $detail->name
+                                        %br
+                                        %span
+                                          %a{ :href => "/donation/#{ $detail->clothes->donation_id }" }= $detail->clothes->donation_id
+                                          = '-'
+                                          %a{ :href => "/user/#{ $detail->clothes->donation->user_id }" }= $detail->clothes->donation->user->name
                                       %td
                                         - if ( $order_status ne '결제대기' && $detail->status ) {
                                           %span.order-status.label{ 'data-order-detail-status' => "#{ $detail->status->name }" }


### PR DESCRIPTION
대여 과정 중 최종 결제 시점에 주문서의 의류를 확인한 후 기증자 한 명을
선택하고 그 이름을 대여자 카드에 작성합니다. 이는 대여자가 기증자에게
대여 메시지를 남길 수 있도록 유도하는 방법인데, 이를 위해 특정 의류를
클릭한 후 들어가서 정보를 확인하고 있습니다. 이 과정을 간소화 시키기
위해 주문서 안에서 각각의 의류 정보 옆에 누가 기증했는지 여부를
보여주고 더불어 추후 메시지 전달을 위해 기증 행위 식별자도 같이
보여줍니다.