### PR TITLE
Update bestfit on socket-onmessage in timetable

### DIFF
--- a/coffee/timetable.coffee
+++ b/coffee/timetable.coffee
@@ -274,6 +274,5 @@ $ ->
     if $box.find('.order-bestfit').data('value') isnt bestfit
       $editable = $box.find('.editable.order-bestfit')
       $editable.editable('setValue', bestfit, true)
-      updateBestfit($editable)
   sock.onerror = (e) ->
     location.reload()

--- a/coffee/timetable.coffee
+++ b/coffee/timetable.coffee
@@ -265,10 +265,15 @@ $ ->
   sock.onmessage = (e) ->
     data     = JSON.parse(e.data)
     order_id = data.order.id
+    bestfit  = data.order.bestfit
     $box     = $(".people-box[data-order-id='#{order_id}']")
     if $box.find('.order-status').data('value') isnt data.to
       $editable = $box.find('.editable.order-status')
       $editable.editable('setValue', data.to, true)
       updateStatus($editable)
+    if $box.find('.order-bestfit').data('value') isnt bestfit
+      $editable = $box.find('.editable.order-bestfit')
+      $editable.editable('setValue', bestfit, true)
+      updateBestfit($editable)
   sock.onerror = (e) ->
     location.reload()


### PR DESCRIPTION
https://github.com/opencloset/monitor/issues/48 를 해결하기 위한 PR 입니다.

모니터에서 bestfit 을 변경하고 변경된 점을 broadcasting 하면 시간표 화면에서 해당 주문서의
어울림항목을 변경합니다.