### PR TITLE
Feature/#264 sms support apistore

### DIFF
--- a/app.conf.sample
+++ b/app.conf.sample
@@ -11,6 +11,20 @@ use Mojo::JSON;
 my $SMS_FROM = '07043257521';
 my $PORT     = 8001;
 
+my %SMS = (
+    driver        => 'KR::APIStore',
+    'KR::CoolSMS' => {
+        _api_key    => $ENV{OPENCLOSET_COOLSMS_API_KEY}    || q{},
+        _api_secret => $ENV{OPENCLOSET_COOLSMS_API_SECRET} || q{},
+        _from       => $SMS_FROM,
+    },
+    'KR::APIStore' => {
+        _id            => $ENV{OPENCLOSET_APISTORE_ID}            || q{},
+        _api_store_key => $ENV{OPENCLOSET_APISTORE_API_STORE_KEY} || q{},
+        _from          => $SMS_FROM,
+    },
+);
+
 my $db_opts = $ENV{OPENCLOSET_DATABASE_OPTS} ? Mojo::JSON::decode_json( $ENV{OPENCLOSET_DATABASE_OPTS} ) : +{
     quote_char        => q{`},
     mysql_enable_utf8 => 1,
@@ -159,8 +173,7 @@ $db_opts->{AutoCommit} //= 1;
         base_url   => "http://localhost:$PORT/api",
         email      => q{},
         password   => q{},
-        api_key    => $ENV{OPENCLOSET_COOLSMS_API_KEY}    || q{},
-        api_secret => $ENV{OPENCLOSET_COOLSMS_API_SECRET} || q{},
+        sms        => \%SMS,
     },
 
     'opencloset-cron.pl' => {
@@ -181,11 +194,7 @@ $db_opts->{AutoCommit} //= 1;
     #
     # SMS
     #
-    sms => {
-        api_key    => $ENV{OPENCLOSET_COOLSMS_API_KEY}    || q{},
-        api_secret => $ENV{OPENCLOSET_COOLSMS_API_SECRET} || q{},
-        from       => $SMS_FROM,
-    },
+    sms => \%SMS,
 
     #
     # session

--- a/bin/opencloset-sms-notifier.pl
+++ b/bin/opencloset-sms-notifier.pl
@@ -7,6 +7,7 @@ use warnings;
 use FindBin qw( $Bin $Script );
 use HTTP::Tiny;
 use JSON;
+use SMS::Send::KR::APIStore;
 use SMS::Send::KR::CoolSMS;
 use SMS::Send;
 use Unicode::GCString;
@@ -45,7 +46,7 @@ while ($continue) {
 
 sub do_work {
     for my $sms ( get_pending_sms_list() ) {
-        print STDERR "$CONF->{fake_sms},SMS::Send::KR::CoolSMS,$sms->{id},$sms->{from},$sms->{to},$sms->{text}\n";
+        print STDERR "$CONF->{fake_sms},$CONF->{sms}{driver},$sms->{id},$sms->{from},$sms->{to},$sms->{text}\n";
 
         #
         # updating status to sending
@@ -68,8 +69,8 @@ sub do_work {
         update_sms(
             $sms,
             status    => 'sent',
-            ret       => $ret || 0,
-            method    => 'SMS::Send::KR::CoolSMS',
+            ret       => $ret->{success} || 0,
+            method    => ( $CONF->{fake_sms} ? 'fake_sms' : $CONF->{sms}{driver} ),
             detail    => encode_json($ret),
             sent_date => time,
         );
@@ -137,15 +138,14 @@ sub send_sms {
         my $gcs  = Unicode::GCString->new($nfc);
         my $cols = $gcs->columns;
 
-        $type = 'LMS' if $cols > 88;
+        $type = 'LMS' if $cols > 80;
     }
 
     my $sender = SMS::Send->new(
-        'KR::CoolSMS',
-        _api_key    => $CONF->{api_key},
-        _api_secret => $CONF->{api_secret},
-        _from       => $sms->{from},
-        _type       => $type,
+        $CONF->{sms}{driver},
+        %{ $CONF->{sms}{ $CONF->{sms}{driver} } },
+        _from => $sms->{from},
+        _type => $type,
     );
 
     my $sent = $sender->send_sms(

--- a/bin/opencloset-sms-notifier.pl
+++ b/bin/opencloset-sms-notifier.pl
@@ -65,7 +65,12 @@ sub do_work {
         #
         # updating status to sent and set return value
         #
-        update_sms( $sms, status => 'sent', ret => $ret || 0 );
+        update_sms(
+            $sms,
+            status    => 'sent',
+            ret       => $ret || 0,
+            sent_date => time,
+        );
 
         sleep $CONF->{send_delay};
     }

--- a/bin/opencloset-sms-notifier.pl
+++ b/bin/opencloset-sms-notifier.pl
@@ -45,7 +45,7 @@ while ($continue) {
 
 sub do_work {
     for my $sms ( get_pending_sms_list() ) {
-        print STDERR "$CONF->{fake_sms},$sms->{id},$sms->{from},$sms->{to},$sms->{text}\n";
+        print STDERR "$CONF->{fake_sms},SMS::Send::KR::CoolSMS,$sms->{id},$sms->{from},$sms->{to},$sms->{text}\n";
 
         #
         # updating status to sending
@@ -59,8 +59,8 @@ sub do_work {
         # if fake_sms is set then fake sending sms
         # then return true always
         #
-        $ret = !$CONF->{fake_sms} ? send_sms($sms) : 1;
-        next unless $ret;
+        $ret = !$CONF->{fake_sms} ? send_sms($sms) : +{ success => 1, fake_sms => 1 };
+        next unless $ret->{success};
 
         #
         # updating status to sent and set return value
@@ -69,6 +69,8 @@ sub do_work {
             $sms,
             status    => 'sent',
             ret       => $ret || 0,
+            method    => 'SMS::Send::KR::CoolSMS',
+            detail    => encode_json($ret),
             sent_date => time,
         );
 
@@ -151,5 +153,5 @@ sub send_sms {
         text => $sms->{text},
     );
 
-    return $sent->{success};
+    return $sent;
 }

--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -3125,7 +3125,7 @@ group {
         #
         # fetch params
         #
-        my %params = $self->get_params(qw/ id from to text status /);
+        my %params = $self->get_params(qw/ id from to text ret status /);
 
         #
         # validate params
@@ -3135,6 +3135,7 @@ group {
         $v->field(qw/ from to /)
             ->each( sub { shift->regexp(qr/^\d+$/) } );
         $v->field('text')->regexp(qr/^.+$/);
+        $v->field('ret')->regexp(qr/^\d+$/);
         $v->field('status')->in(qw/ pending sending sent /);
 
         unless ( $self->validate( $v, \%params ) ) {

--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -3125,7 +3125,7 @@ group {
         #
         # fetch params
         #
-        my %params = $self->get_params(qw/ id from to text ret status /);
+        my %params = $self->get_params(qw/ id from to text ret status sent_date /);
 
         #
         # validate params
@@ -3137,6 +3137,7 @@ group {
         $v->field('text')->regexp(qr/^.+$/);
         $v->field('ret')->regexp(qr/^\d+$/);
         $v->field('status')->in(qw/ pending sending sent /);
+        $v->field('sent_date')->regexp(qr/^\d+$/);
 
         unless ( $self->validate( $v, \%params ) ) {
             my @error_str;
@@ -3147,6 +3148,13 @@ group {
                 str  => join(',', @error_str),
                 data => $v->errors,
             }), return;
+        }
+
+        if ( $params{sent_date} ) {
+            $params{sent_date} = DateTime->from_epoch(
+                epoch     => $params{sent_date},
+                time_zone => app->config->{timezone},
+            );
         }
 
         #

--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -3125,7 +3125,7 @@ group {
         #
         # fetch params
         #
-        my %params = $self->get_params(qw/ id from to text ret status sent_date /);
+        my %params = $self->get_params(qw/ id from to text ret status method detail sent_date /);
 
         #
         # validate params

--- a/cpanfile
+++ b/cpanfile
@@ -28,6 +28,7 @@ requires 'Parcel::Track::KR::KGB';
 requires 'Parcel::Track::KR::PostOffice';
 requires 'Parcel::Track::KR::Yellowcap';
 requires 'Path::Tiny';
+requires 'SMS::Send::KR::APIStore', '0.001';
 requires 'SMS::Send::KR::CoolSMS', '1.003';
 requires 'Scalar::Util';
 requires 'Statistics::Basic';

--- a/templates/sms.html.haml
+++ b/templates/sms.html.haml
@@ -35,9 +35,9 @@
           %br
           %span
             %span.msg-screen-width= '0'
-            = ' / 88'
+            = ' / 80'
         .col-sm-9
-          %textarea.col-xs-10.col-sm-8{ :name => "msg", :placeholder => "한글 기준 44자가 넘지 않을 경우 SMS로, 넘을 경우 LMS로 전송합니다.", :rows => "5" }= $msg
+          %textarea.col-xs-10.col-sm-8{ :name => "msg", :placeholder => "한글 기준 40자가 넘지 않을 경우 SMS로, 넘을 경우 LMS로 전송합니다.", :rows => "5" }= $msg
       .form-actions.clearfix
         .col-md-offset-3.col-md-9
           %button.btn.btn-info#btn-sms-send{ :type => 'button' }


### PR DESCRIPTION
- 웹 응용에서 기존의 존재했지만 갱신할 수 없었던 `sms.ret`와 `sms.sent_date` 항목을 갱신 가능하도록 수정
- 웹 응용 및 sms 전송 스크립트에서 `sms.method`와 `sms.detail` 값을 갱신할 수 있도록 지원
- APIStore SMS 전송 드라이버를 지원