### PR TITLE
formatting currency like "50,000원"

### DIFF
--- a/coffee/visit.coffee
+++ b/coffee/visit.coffee
@@ -579,13 +579,16 @@ $ ->
       LATE_FEE_RATE = 0.2
       lateFee = expectedCost * lateDay * LATE_FEE_RATE
       $('#expected-fee').data('expected-fee', expectedCost).html """
-        <samp>#{(expectedCost + lateFee).toLocaleString()} = #{(expectedCost).toLocaleString()} + #{(lateFee).toLocaleString()}</samp>
+        <samp>#{(expectedCost + lateFee).commify()} = #{(expectedCost).commify()} + #{(lateFee).commify()}</samp>
         <br>
         <small class="text-muted">총대여비 = 기본대여비 + #{lateDay}일 추가연장비</small>
       """
     else
       $('#latefee-help').hide()
       $('#expected-fee').data('expected-fee', expectedCost).html """
-        <samp>#{expectedCost.toLocaleString()}</samp>
+        <samp>#{expectedCost.commify()}</samp>
         <small class="text-muted">총대여비</small>
       """
+
+Number.prototype.commify = ->
+  @toFixed(0).replace(/(\d)(?=(\d{3})+(?:\.\d+)?$)/g, "$1,") + '원'

--- a/coffee/visit.coffee
+++ b/coffee/visit.coffee
@@ -579,16 +579,13 @@ $ ->
       LATE_FEE_RATE = 0.2
       lateFee = expectedCost * lateDay * LATE_FEE_RATE
       $('#expected-fee').data('expected-fee', expectedCost).html """
-        <samp>#{(expectedCost + lateFee).commify()} = #{(expectedCost).commify()} + #{(lateFee).commify()}</samp>
+        <samp>#{OpenCloset.commify(expectedCost + lateFee)}원 = #{OpenCloset.commify(expectedCost)}원 + #{OpenCloset.commify(lateFee)}원</samp>
         <br>
         <small class="text-muted">총대여비 = 기본대여비 + #{lateDay}일 추가연장비</small>
       """
     else
       $('#latefee-help').hide()
       $('#expected-fee').data('expected-fee', expectedCost).html """
-        <samp>#{expectedCost.commify()}</samp>
+        <samp>#{OpenCloset.commify(expectedCost)}원</samp>
         <small class="text-muted">총대여비</small>
       """
-
-Number.prototype.commify = ->
-  @toFixed(0).replace(/(\d)(?=(\d{3})+(?:\.\d+)?$)/g, "$1,") + '원'


### PR DESCRIPTION
#407 

    50000.toLocaleString()    # 50,000

처럼 나와야 하는데, 아이폰 사파리 브라우저에서는 `50000` 으로 표기됩니다.
해서 화폐단위로 포맷팅 하는 `commify` 라는 prototype 함수를 추가해서 대신 사용합니다.

    50000.commify()    # 50,000원