### PR TITLE
대여화면에서 대여중인 주문서의 상태를 결제대기로 바꾸지 못하게 함

### DIFF
--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -4983,9 +4983,19 @@ post '/order' => sub {
             my $order = $DB->resultset('Order')->find( $order_params{id} );
             die "order not found: $order_params{id}\n" unless $order;
 
+            my @invalid = (
+                2,  # 대여중
+                9,  # 반납
+                10, # 부분반납
+                11, # 반납배송중
+                12, # 방문안함
+                19, # 결제대기
+                40, # 대여안함
+                42, # 환불
+                43, # 사이즈없음
+            );
             my $status_id = $order->status_id;
-            my @invalid = qw/2 9 10 11 12 19 40 42 43/;
-            if (grep {/^$status_id$/} @invalid) {
+            if ( $status_id ~~ @invalid ) {
                 my $status = $DB->resultset('Status')->find( $status_id )->name;
                 die "이미 $status 인 주문서 입니다.\n";
             }

--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -4983,6 +4983,13 @@ post '/order' => sub {
             my $order = $DB->resultset('Order')->find( $order_params{id} );
             die "order not found: $order_params{id}\n" unless $order;
 
+            my $status_id = $order->status_id;
+            my @invalid = qw/2 9 10 11 12 19 40 42 43/;
+            if (grep {/^$status_id$/} @invalid) {
+                my $status = $DB->resultset('Status')->find( $status_id )->name;
+                die "이미 $status 인 주문서 입니다.\n";
+            }
+
             #
             # 주문서를 결제대기(19) 상태로 변경
             #
@@ -5044,7 +5051,7 @@ post '/order' => sub {
             return ( undef, $_ );
         }
     };
-    return unless $order;
+    return $self->error(500, {str => $error}) unless $order;
 
     #
     # response

--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -4977,6 +4977,8 @@ post '/order' => sub {
     my ( $order, $error ) = do {
         my $guard = $DB->txn_scope_guard;
         try {
+            use experimental qw( smartmatch );
+
             #
             # find order
             #

--- a/templates/exception.html.ep
+++ b/templates/exception.html.ep
@@ -45,7 +45,7 @@
                     <div class="space"></div>
 
                     <div class="center">
-                      <a href="#" class="btn btn-grey">
+                      <a href="<%= $self->req->headers->referrer %>" class="btn btn-grey">
                         <i class="icon-arrow-left"></i>
                         Go Back
                       </a>

--- a/templates/exception.html.ep
+++ b/templates/exception.html.ep
@@ -13,7 +13,7 @@
                         <i class="icon-random"></i>
                         500
                       </span>
-                      <%= $exception->message %>
+                      <%= $error %>
                     </h1>
 
                     <hr />


### PR DESCRIPTION
#493 

![screenshot-localhost 5001 2015-06-23 14-45-36](https://cloud.githubusercontent.com/assets/170528/8299661/a0c68fb6-19b6-11e5-9b23-f25fc559dc0e.png)

이렇듯 잘못진행되었을때는 `Go Back` 버튼을 눌러서 다시 진행합니다.