### PR TITLE
input field 안에서의 바로가기 지원

### DIFF
--- a/templates/layouts/default/body-js-page.html.ep
+++ b/templates/layouts/default/body-js-page.html.ep
@@ -14,12 +14,15 @@
     % }
 
     <script>
+      // https://craig.is/killing/mice#api.stopCallback
+      // Mousetrap.stopCallback = function (e, el) { return false }    // not working
+      Mousetrap.prototype.stopCallback = function (e, el) { return false }
     % for my $k ( keys %{ $sidebar->{meta} } ) {
     %   my $v        = $sidebar->{meta}{$k};
     %   my $shortcut = $v->{shortcut};
     %   my $link     = $v->{link} || "/$k";
     %   next unless $shortcut;
-      Mousetrap.bind('<%= $shortcut %>', function() { location.href = '<%= $link %>'; });
+      Mousetrap.bind('ctrl+<%= $shortcut %>', function() { location.href = '<%= $link %>'; });
     % }
       Mousetrap.bind('?', function() { return $.facebox({ ajax: '/shortcut' }); });
     </script>

--- a/templates/shortcut.html.ep
+++ b/templates/shortcut.html.ep
@@ -8,6 +8,6 @@
 %   my $v        = $sidebar->{meta}{$k};
 %   my $shortcut = $v->{shortcut};
 %   my $text     = $v->{text};
-  <li> <kbd><%= $shortcut %></kbd> <%= $text %> </li>
+  <li> <kbd>ctrl+<%= $shortcut %></kbd> <%= $text %> </li>
 % }
 </ul>


### PR DESCRIPTION
#483 

단축키를 전부 `ctrl+1` ~ `ctrl+9` 로 바꾸고 어디에서든 눌려질 수 있도록 하였습니다.