### PR TITLE
Add timetable link at recent-order

### DIFF
--- a/templates/partials/recent-orders.html.haml
+++ b/templates/partials/recent-orders.html.haml
@@ -36,4 +36,11 @@
                                     .time
                                       %i.icon-time.bigger-110
                                       = $order->create_date->ymd . q{ } . $order->create_date->hms
+                                      - my $booking_date = $order->booking->date;
+                                      - my $booking_ymd  = $booking_date->ymd;
+                                      - my $booking_hhmm = sprintf "%02d%02d", $booking_date->hour, $booking_date->minute;
+                                      %i.icon-calendar.bigger-110
+                                      %a{:href => '#{url_for("/timetable/" . $booking_ymd)->fragment("timetable-$booking_hhmm")}', :title => '시간표'}
+                                        = $booking_ymd
+                                        = $booking_date->hms
                               - }


### PR DESCRIPTION
#510 

![screenshot-localhost 5001 2015-07-08 15-42-27](https://cloud.githubusercontent.com/assets/170528/8564529/0aa2a744-2588-11e5-8d8a-effdf3fcb2d9.png)

사용자화면에서 최근 주문란에 해당 시간표로 이동할 수 있는 링크를 넣었습니다.