### PR TITLE
Add extra condition for filter out online order

### DIFF
--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -5936,7 +5936,7 @@ get '/stat/status/:ymd' => sub {
             day       => 29
         );
     };
-    my $online_order_hour = $dt >= $basis_dt ? 12 + 10 : 12 + 7;
+    my $online_order_hour = $dt >= $basis_dt ? 22 : 19;
 
     my $dtf      = $DB->storage->datetime_parser;
     my $order_rs = $DB->resultset('Order')->search(
@@ -5952,7 +5952,7 @@ get '/stat/status/:ymd' => sub {
                         $dtf->format_datetime($dt_end),
                     ],
                 },
-                \[ 'HOUR(`booking`.`date`) != ?', $online_order_hour ]
+                \[ 'HOUR(`booking`.`date`) != ?', $online_order_hour ],
             ]
         },
         {


### PR DESCRIPTION
열린옷장은 내부적으로 2015년 5월 29일을 기준으로 이 시점 이전에는
온라인주문을 오후 7시(19시) 시간대에 배정했고 이후에는 오후 10시(22시)
시간대에 배정했습니다. 이 규칙을 반영해서 통계 결과에서 온라인주문이
추가되지 않도록 했습니다.