### PR TITLE
Remove example text to pull up time table (#547)

### DIFF
--- a/templates/visit-info-box.html.ep
+++ b/templates/visit-info-box.html.ep
@@ -260,11 +260,6 @@
                             참고하셔서 경제적으로 대여하시기 바랍니다.
                           </p>
 
-                          <p>
-                            예)<br />
-                            옷이 필요한 날 - 12월 5일<br />
-                            적절한 예약일  - 12월 3일 또는 12월 4일
-                          </p>
                         </div>
                         <table id="booking-table" class="table table-striped table-bordered table-hover">
                           <thead>

--- a/templates/visit2-info-box.html.ep
+++ b/templates/visit2-info-box.html.ep
@@ -253,11 +253,6 @@
                             참고하셔서 경제적으로 대여하시기 바랍니다.
                           </p>
 
-                          <p>
-                            예)<br />
-                            옷이 필요한 날 - 12월 5일<br />
-                            적절한 예약일  - 12월 3일 또는 12월 4일
-                          </p>
                         </div>
                         <table id="booking-table" class="table table-striped table-bordered table-hover">
                           <thead>


### PR DESCRIPTION
처리한 내역은 다음과 같습니다.

- 아래의 시간표 영역을 위로 끌어올리기 위해서 대여 관련 날짜 예제 문구를 제거