### PR TITLE
Feature/#578 search clothes list

### DIFF
--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -4569,7 +4569,22 @@ get '/clothes' => sub {
     #
     # fetch params
     #
-    my %params = $self->get_params(qw/ status tag /);
+    my %params = $self->get_params(qw/
+        arm
+        belly
+        bust
+        category
+        color
+        gender
+        hip
+        length
+        neck
+        status
+        tag
+        thigh
+        topbelly
+        waist
+    /);
 
     #
     # validate params
@@ -4577,6 +4592,12 @@ get '/clothes' => sub {
     my $v = $self->create_validator;
     $v->field('status')->regexp(qr/^\d+$/);
     $v->field('tag')->regexp(qr/^\d+$/);
+    $v->field('category')->required(1)->in( keys %{ app->config->{category} } );
+    $v->field('gender')->in(qw/ male female unisex /);
+    $v->field(qw/ arm belly bust hip length neck thigh topbelly waist /)->each(sub {
+        shift->regexp(qr/^\d{1,3}$/);
+    });
+
     unless ( $self->validate( $v, \%params ) ) {
         my @error_str;
         while ( my ( $k, $v ) = each %{ $v->errors } ) {
@@ -4623,14 +4644,38 @@ get '/clothes' => sub {
     #
     # search clothes
     #
-    my $p      = $self->param('p') || 1;
-    my $s      = $self->param('s') || app->config->{entries_per_page};
-    my $status = $self->param('status');
-    my $tag    = $self->param('tag');
+    my $p        = $self->param('p') || 1;
+    my $s        = $self->param('s') || app->config->{entries_per_page};
+    my $status   = $self->param('status');
+    my $tag      = $self->param('tag');
+    my $arm      = $self->param('arm');
+    my $belly    = $self->param('belly');
+    my $bust     = $self->param('bust');
+    my $category = $self->param('category');
+    my $color    = $self->param('color');
+    my $gender   = $self->param('gender');
+    my $hip      = $self->param('hip');
+    my $length   = $self->param('length');
+    my $neck     = $self->param('neck');
+    my $thigh    = $self->param('thigh');
+    my $topbelly = $self->param('topbelly');
+    my $waist    = $self->param('waist');
 
     my $cond = {};
-    $cond->{status_id}             = $status if $status;
-    $cond->{'clothes_tags.tag_id'} = $tag    if $tag;
+    $cond->{status_id}             = $status   if $status;
+    $cond->{'clothes_tags.tag_id'} = $tag      if $tag;
+    $cond->{'arm'}                 = $arm      if defined $arm;
+    $cond->{'belly'}               = $belly    if defined $belly;
+    $cond->{'bust'}                = $bust     if defined $bust;
+    $cond->{'category'}            = $category if defined $category;
+    $cond->{'color'}               = $color    if defined $color;
+    $cond->{'gender'}              = $gender   if defined $gender;
+    $cond->{'hip'}                 = $hip      if defined $hip;
+    $cond->{'length'}              = $length   if defined $length;
+    $cond->{'neck'}                = $neck     if defined $neck;
+    $cond->{'thigh'}               = $thigh    if defined $thigh;
+    $cond->{'topbelly'}            = $topbelly if defined $topbelly;
+    $cond->{'waist'}               = $waist    if defined $waist;
 
     my $attrs = {
         order_by => { -asc => 'id' },

--- a/templates/stat-clothes-amount-category-gender.html.haml
+++ b/templates/stat-clothes-amount-category-gender.html.haml
@@ -34,13 +34,24 @@
           %th 폐기
       %tbody
         - for my $item (@$items) {
+        -   my %query_params = (
+        -     category   => $category,
+        -     gender     => $gender,
+        -     $criterion => $item->{size},
+        -   );
           %tr
             %td= $item->{size} || '사이즈 기준 항목 없음'
-            %td= $item->{qty}
+            %td
+              %a{ :href => "#{ url_for( '/clothes' )->query( %query_params ) }" }= $item->{qty}
             %td= $item->{available_qty}
-            %td= $item->{rental}
-            %td= $item->{repair}
-            %td= $item->{cleaning}
-            %td= $item->{lost}
-            %td= $item->{disused}
+            %td
+              %a{ :href => "#{ url_for( '/clothes' )->query( %query_params, status => 2 ) }" }= $item->{rental}
+            %td
+              %a{ :href => "#{ url_for( '/clothes' )->query( %query_params, status => 6 ) }" }= $item->{repair}
+            %td
+              %a{ :href => "#{ url_for( '/clothes' )->query( %query_params, status => 5 ) }" }= $item->{cleaning}
+            %td
+              %a{ :href => "#{ url_for( '/clothes' )->query( %query_params, status => 7 ) }" }= $item->{lost}
+            %td
+              %a{ :href => "#{ url_for( '/clothes' )->query( %query_params, status => 8 ) }" }= $item->{disused}
         - }


### PR DESCRIPTION
처리한 내역은 다음과 같습니다.

- 의류 목록을 보여주는 페이지(`/clothes`)에서 기존 `status`와 `tag`이외에도 `arm`, `belly`, `bust`, `category`, `color`, `gender`, `hip`, `length`, `neck`, `thigh`, `topbelly`, `waist` 항목을 이용해 추가로 더 검색할 수 있도록 함
- 통계-수량-의류 종류 페이지에서 개수 숫자를 클릭시 해당 조건의 의류 목록 페이지를 보여주는 링크를 추가함