### PR TITLE
Feature/#566 user profile display avg data

### DIFF
--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -1513,6 +1513,7 @@ group {
     put  '/gui/booking/:id'       => \&api_gui_update_booking;
     get  '/gui/booking-list'      => \&api_gui_booking_list;
     get  '/gui/timetable/:ymd'    => \&api_gui_timetable;
+    get  '/gui/user/:id/avg'      => \&api_gui_user_id_avg;
 
     any '/postcode/search'       => \&api_postcode_search;
 
@@ -3906,6 +3907,58 @@ group {
 
         $self->respond_to( json => { status => 200, json => \%count } );
 
+    }
+
+    sub api_gui_user_id_avg {
+        my $self = shift;
+
+        #
+        # fetch params
+        #
+        my %params = $self->get_params(qw/ id /);
+
+        my $user = $self->get_user( \%params );
+        return unless $user;
+
+        my %data = (
+            ret  => 0,
+            diff => undef,
+            avg  => undef,
+        );
+
+        unless (
+            $user->user_info->gender =~ m/^(male|female)$/
+            && $user->user_info->height
+            && $user->user_info->weight
+        )
+        {
+            $self->respond_to( json => { status => 200, json => \%data } );
+            return;
+        }
+
+        my $osg_db = OpenCloset::Size::Guess->new(
+            'DB',
+            _time_zone => app->config->{timezone},
+            _schema    => $DB,
+            _range     => 0,
+        );
+        $osg_db->gender( $user->user_info->gender );
+        $osg_db->height( int $user->user_info->height );
+        $osg_db->weight( int $user->user_info->weight );
+        my $avg = $osg_db->guess;
+        my $diff;
+        for ( qw/ neck belly topbelly bust arm thigh waist hip leg foot knee / ) {
+            $diff->{$_} = $user->user_info->$_ && $avg->{$_} ? sprintf( '%+.1f', $user->user_info->$_ - $avg->{$_} ) : '-';
+            $avg->{$_}  = $avg->{$_} ? sprintf('%.1f', $avg->{$_}) : 'N/A';
+        }
+
+        %data = (
+            ret  => 1,
+            diff => $diff,
+            avg  => $avg,
+        );
+
+        $self->respond_to( json => { status => 200, json => \%data } );
     }
 
     sub api_postcode_search {

--- a/coffee/user-id.coffee
+++ b/coffee/user-id.coffee
@@ -1,4 +1,23 @@
 $ ->
+  updateAverageDiff = ->
+    userID = $('#profile-user-info-data').data('pk')
+    $.ajax "/api/gui/user/#{userID}/avg.json",
+      type: 'GET'
+      success: (data, textStatus, jqXHR) ->
+        if data.ret is 1
+          for i in [ 'neck', 'belly', 'topbelly', 'bust', 'arm', 'thigh', 'waist', 'hip', 'leg', 'foot', 'knee' ]
+            $(".#{i} .diff").html( data.diff[i] )
+            $(".#{i} .avg").html( data.avg[i] )
+        else
+          OpenCloset.alert('warning', "키, 몸무게, 성별의 오류로 평균값을 구할 수 없습니다.")
+          for i in [ 'neck', 'belly', 'topbelly', 'bust', 'arm', 'thigh', 'waist', 'hip', 'leg', 'foot', 'knee' ]
+            $(".#{i} .diff").html( '-' )
+            $(".#{i} .avg").html( 'N/A' )
+      error: (jqXHR, textStatus, errorThrown) ->
+        type = jqXHR.status is 404 ? 'warning' : 'danger'
+        OpenCloset.alert(type, "평균값을 구할 수 없습니다: #{jqXHR.status}")
+      complete: (jqXHR, textStatus) ->
+
   $('.order-status').each (i, el) ->
     $(el).addClass OpenCloset.status[ $(el).data('status') ].css
     $(el).find('.order-status-str').html('연장중') if $(el).data('status') is '대여중' and $(el).data('late-fee') > 0
@@ -121,6 +140,9 @@ $ ->
           $.ajax url,
             type: 'PUT'
             data: data
+      when 'user-height', 'user-weight', 'user-neck', 'user-bust', 'user-waist', 'user-topbelly', 'user-belly', 'user-arm', 'user-leg', 'user-knee', 'user-thigh', 'user-hip', 'user-foot'
+        params.success = (response, newValue) ->
+          updateAverageDiff()
       else
         params.type = 'text'
 

--- a/sass/screen.scss
+++ b/sass/screen.scss
@@ -467,6 +467,27 @@ $opencloset-darken-yellow: desaturate(darken($opencloset-yellow, 4%), 10%);
                 text-decoration: none;
             }
         }
+        .profile-info-value > span + span.diff::before {
+            border-bottom: 1px solid #fff;
+            color: #666;
+            content: "(";
+            display: inline;
+            margin-left: 3px;
+            margin-right: 1px;
+        }
+        .profile-info-value > span + span.diff::after {
+            content: ")";
+            display: inline;
+            margin-left: 1px;
+        }
+        .profile-info-value > span + span.avg::before {
+            border-bottom: 1px solid #fff;
+            color: #666;
+            content: "";
+            display: inline;
+            margin-left: 1px;
+            margin-right: 30px;
+        }
     }
     #clothes {
         #clothes-list-table table {

--- a/templates/user-id.html.haml
+++ b/templates/user-id.html.haml
@@ -168,60 +168,82 @@
                                 .profile-info-value
                                   %span.editable#user-weight{ 'data-name' => 'weight' }= $user->user_info->weight
 
-                              .profile-info-row
+                              .profile-info-row.neck
                                 .profile-info-name 목 둘레
                                 .profile-info-value
                                   %span.editable#user-neck{ 'data-name' => 'neck' }= $user->user_info->neck
+                                  %span.diff= $diff->{neck}
+                                  %span.avg= $avg->{neck}
 
-                              .profile-info-row
+                              .profile-info-row.bust
                                 .profile-info-name 가슴 둘레
                                 .profile-info-value
                                   %span.editable#user-bust{ 'data-name' => 'bust' }= $user->user_info->bust
+                                  %span.diff= $diff->{bust}
+                                  %span.avg= $avg->{bust}
 
-                              .profile-info-row
+                              .profile-info-row.waist
                                 .profile-info-name 허리 둘레
                                 .profile-info-value
                                   %span.editable#user-waist{ 'data-name' => 'waist' }= $user->user_info->waist
+                                  %span.diff= $diff->{waist}
+                                  %span.avg= $avg->{waist}
 
-                              .profile-info-row
+                              .profile-info-row.topbelly
                                 .profile-info-name 윗배 둘레
                                 .profile-info-value
                                   %span.editable#user-topbelly{ 'data-name' => 'topbelly' }= $user->user_info->topbelly
+                                  %span.diff= $diff->{topbelly}
+                                  %span.avg= $avg->{topbelly}
 
-                              .profile-info-row
+                              .profile-info-row.belly
                                 .profile-info-name 배꼽 둘레
                                 .profile-info-value
                                   %span.editable#user-belly{ 'data-name' => 'belly' }= $user->user_info->belly
+                                  %span.diff= $diff->{belly}
+                                  %span.avg= $avg->{belly}
 
-                              .profile-info-row
+                              .profile-info-row.arm
                                 .profile-info-name 팔 길이
                                 .profile-info-value
                                   %span.editable#user-arm{ 'data-name' => 'arm' }= $user->user_info->arm
+                                  %span.diff= $diff->{arm}
+                                  %span.avg= $avg->{arm}
 
-                              .profile-info-row
+                              .profile-info-row.leg
                                 .profile-info-name 다리 길이
                                 .profile-info-value
                                   %span.editable#user-leg{ 'data-name' => 'leg' }= $user->user_info->leg
+                                  %span.diff= $diff->{leg}
+                                  %span.avg= $avg->{leg}
 
-                              .profile-info-row
+                              .profile-info-row.knee
                                 .profile-info-name 무릎 길이
                                 .profile-info-value
                                   %span.editable#user-knee{ 'data-name' => 'knee' }= $user->user_info->knee
+                                  %span.diff= $diff->{knee}
+                                  %span.avg= $avg->{knee}
 
-                              .profile-info-row
+                              .profile-info-row.thigh
                                 .profile-info-name 허벅지 둘레
                                 .profile-info-value
                                   %span.editable#user-thigh{ 'data-name' => 'thigh' }= $user->user_info->thigh
+                                  %span.diff= $diff->{thigh}
+                                  %span.avg= $avg->{thigh}
 
-                              .profile-info-row
+                              .profile-info-row.hip
                                 .profile-info-name 엉덩이 둘레
                                 .profile-info-value
                                   %span.editable#user-hip{ 'data-name' => 'hip' }= $user->user_info->hip
+                                  %span.diff= $diff->{hip}
+                                  %span.avg= $avg->{hip}
 
-                              .profile-info-row
+                              .profile-info-row.foot
                                 .profile-info-name 발 크기
                                 .profile-info-value
                                   %span.editable#user-foot{ 'data-name' => 'foot' }= $user->user_info->foot
+                                  %span.diff= $diff->{foot}
+                                  %span.avg= $avg->{foot}
 
                               .profile-info-row
                                 .profile-info-name 바지 길이


### PR DESCRIPTION
처리한 내역은 다음과 같습니다.

- 사용자 정보 페이지에서 해당 사용자의 성별, 키, 몸무게 값을 기준으로 각 신체 치수 항목의 평균 및 편차를 치수 옆에 표시하도록 함
- 사용자 정보 페이지에서 사용자의 성별, 키, 몸무게 값을 수정할 때 마다 즉석에서 서버로 평균 및 편차 값을 요청해서 가장 최신의 값으로 갱신하도록 함