### PR TITLE
Feature/#555 hyphen search and send sms

### DIFF
--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -3111,7 +3111,7 @@ group {
         # validate params
         #
         my $v = $self->create_validator;
-        $v->field('to')->required(1)->regexp(qr/^[0-9]{3}-?[0-9]{3,4}-?[0-9]{3,4}$/);
+        $v->field('to')->required(1)->regexp(qr/^\d+$/);
         $v->field('text')->required(1)->regexp(qr/^(\s|\S)+$/);
         $v->field('status')->in(qw/ pending sending sent /);
 

--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -4532,15 +4532,16 @@ get '/user' => sub {
     my $q     = $self->param('q');
     my $staff = $self->param('staff');
 
-    if ($q && $q =~ m/^[0-9]{3}-?[0-9]{3,4}-?[0-9]{3,4}$/) {
-        $q =~ s/-//g;
+    my $q_phone = $q;
+    if ( $q_phone ) {
+        $q_phone =~ s/\D//g;
     }
 
     my $cond1 = $q
         ? [
         { 'name'               => { like => "%$q%" } },
         { 'email'              => { like => "%$q%" } },
-        { 'user_info.phone'    => { like => "%$q%" } },
+        { 'user_info.phone'    => { like => "%$q_phone%" } },
         { 'user_info.address4' => { like => "%$q%" } },    # 상세주소만 검색
         { 'user_info.birth'    => { like => "%$q%" } },
         { 'user_info.gender'   => $q },

--- a/coffee/sms.coffee
+++ b/coffee/sms.coffee
@@ -40,6 +40,11 @@ $ ->
     .on( 'change', (e) -> updateMsgScreenWidth() )
 
   #
+  # 전화번호에 `-` 기호를 무시하도록 함
+  #
+  $('input[type="tel"]').mask('00000000000')
+
+  #
   # dynamic chosen item manupulation
   # http://stackoverflow.com/questions/11352207/jquery-chosen-plugin-add-options-dynamically
   #
@@ -60,7 +65,7 @@ $ ->
       OpenCloset.alert 'danger', '휴대전화를 입력해주세요.'
       $('input[name=to]').focus()
       return
-    unless /^\d{3}-?\d{3,4}-?\d{3,4}$/.test( to )
+    unless /^\d+$/.test( to )
       OpenCloset.alert 'danger', '유효하지 않은 휴대전화입니다.'
       $('input[name=to]').focus()
       return

--- a/templates/sms.html.haml
+++ b/templates/sms.html.haml
@@ -1,6 +1,11 @@
 - use utf8;
 - my $_id = 'sms';
-- layout 'default', page_id => $_id;
+- layout 'default',
+-   page_id => $_id,
+-   jses    => [
+-     '/lib/jquery/js/jquery.mask.min.js',
+-   ],
+-   ;
 - title meta_text($_id);
 
 .row


### PR DESCRIPTION
처리한 내역은 다음과 같습니다.

- 문자 전송 페이지에서 브라우저 차원에서 숫자 이외의 기호를 제거하도록 했으며 서버측에서는 전화번호는 숫자만 허용하는 예전 방식으로 되돌립니다.
- 사용자 검색시 검색 질의 생성할 때 전화번호에 한해서만 질의에서 숫자 이외의 기호를 제거하도록 합니다.
