### PR TITLE
예약 취소 기능 추가

### DIFF
--- a/coffee/booking.coffee
+++ b/coffee/booking.coffee
@@ -33,6 +33,8 @@ $ ->
   $('.order-cancel').click (e) ->
     e.preventDefault()
 
+    return unless confirm "취소하시겠습니까?"
+
     $this = $(@)
     to   = $this.data('phone')
     name = $this.data('name')

--- a/coffee/booking.coffee
+++ b/coffee/booking.coffee
@@ -29,3 +29,23 @@ $ ->
 
     params.type = 'text'
     $(el).editable params
+
+  $('.order-cancel').click (e) ->
+    e.preventDefault()
+
+    $this = $(@)
+    to   = $this.data('phone')
+    name = $this.data('name')
+    msg  = $this.attr('title')
+    url  = $this.attr('href')
+
+    OpenCloset.sendSMS to, msg
+
+    $.ajax url,
+      type: 'DELETE'
+      success: (data, textStatus, jqXHR) ->
+        $this.closest('span.dropdown').remove()
+        OpenCloset.alert 'success', "#{name}님 예약이 취소 되었습니다"
+      error: (jqXHR, textStatus, errorThrown) ->
+        OpenCloset.alert 'error', textStatus
+      complete: (jqXHR, textStatus) ->

--- a/templates/booking.html.haml
+++ b/templates/booking.html.haml
@@ -101,7 +101,7 @@
                     %li
                       %a.order-cancel{:href => "#{url_for('/api/order/' . $order->id)}", :title => "#{$u->name}님 [#{param('ymd')}] 열린옷장 방문 예약이 취소되었습니다.", :data-phone => $user_info->phone, :data-name => $u->name}
                         %i.icon-warning-sign.red
-                        예약취소
+                        예약 취소
               -   }
               - }
           - }

--- a/templates/booking.html.haml
+++ b/templates/booking.html.haml
@@ -90,7 +90,18 @@
             %td
               - if ($users) {
               -   for my $u (@$users) {
-                %a{ :href => "#{ url_for( '/user/' . $u->id ) }" }= $u->name
+                - my $user_info = $u->user_info;
+                - my $order = $booking->orders({ user_id => $u->id })->first;
+                %span.dropdown
+                  %a{:href => '#', :data-toggle => 'dropdown'}
+                    = $u->name
+                  %ul.dropdown-menu
+                    %li
+                      %a{:href => "#{url_for( '/user/' . $u->id )}"} 사용자 정보
+                    %li
+                      %a.order-cancel{:href => "#{url_for('/api/order/' . $order->id)}", :title => "#{$u->name}님 [#{param('ymd')}] 열린옷장 방문 예약이 취소되었습니다.", :data-phone => $user_info->phone, :data-name => $u->name}
+                        %i.icon-warning-sign.red
+                        예약취소
               -   }
               - }
           - }


### PR DESCRIPTION
#652 

![screenshot-localhost 5001 2015-12-31 10-15-52](https://cloud.githubusercontent.com/assets/170528/12059888/9578de98-afa7-11e5-8e32-a0430142f536.png)

예약메뉴에서 사용자의 이름을 클릭하면 sub 메뉴가 나타나고 거기서 예약 취소를 할 수 있는 기능입니다.

사용자에게는 아래의 문자메세지가 전송되고 주문서는 삭제됩니다.

    xxx님 [xxxx-xx-xx] 열린옷장 방문 예약이 취소되었습니다.