### PR TITLE
주문서에 합격 버튼을 추가

### DIFF
--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -2234,6 +2234,7 @@ group {
             neck
             pants
             parent_id
+            pass
             price_pay_with
             purpose
             purpose2

--- a/coffee/order-id.coffee
+++ b/coffee/order-id.coffee
@@ -374,6 +374,28 @@ $ ->
     $('#order-late-fee-pay-with').editable 'setValue', ''
     $('#order-late-fee-pay-with').html '결제 방법 선택'
 
+  #
+  # 합격 버튼 클릭
+  #
+  $('#btn-interview-pass:not(.disabled)').click (e) ->
+    $this    = $(@)
+    pass     = if $this.hasClass('btn-success') then 0 else 1
+    order_id = $('#order').data('order-id')
+
+    $this.addClass('disabled')
+
+    $.ajax "/api/order/#{order_id}",
+      type: 'PUT'
+      data: { pass: pass }
+      dataType: 'json'
+      success: (data, textStatus, jqXHR) ->
+        if $this.hasClass('btn-success')
+          $this.removeClass('btn-success').addClass('btn-default').html('합격하셨나요?')
+        else
+          $this.removeClass('btn-default').addClass('btn-success').html('합격')
+      complete: ->
+        $this.removeClass('disabled')
+
   returnClothesReal = (type, redirect_url, order_id, late_fee_pay_with, compensation_pay_with) ->
     if type is 'part'
       #

--- a/templates/order-id.html.haml
+++ b/templates/order-id.html.haml
@@ -492,6 +492,13 @@
                         %a#btn-refund-process.btn.btn-danger.pull-right.return-process-reverse{ :type => 'button' }
                           %i.icon-remove.bigger-110
                           환불 진행
+                        - if ($order->pass) {
+                          %a#btn-interview-pass.btn.btn-success.pull-right.return-process-reverse{ :type => 'button' }
+                            합격
+                        - } else {
+                          %a#btn-interview-pass.btn.btn-default.pull-right.return-process-reverse{ :type => 'button' }
+                            합격하셨나요?
+                        - }
                         %a#btn-return-all.btn.btn-success.disabled.pull-right.return-process{ :type => 'button', 'data-redirect-url' => "#{ url_for('/order/' . $order->id) }" }
                           %i.icon-ok.bigger-110
                           전체 반납


### PR DESCRIPTION
#655 

`opencloset` DB 에서 OpenCloset-Schema#39-column-pass 브랜치의
db/alter/order-add-column-pass.sql 을 실행시킵니다.

`order` 테이블에 `pass` 컬럼이 생기고, 대여중인 주문서를 들어가면
합격에 관련한 버튼이 반납, 환불 버튼과 함께 보입니다.

![screenshot-localhost 5001 2016-01-19 12-22-32](https://cloud.githubusercontent.com/assets/170528/12408844/e66ee0fe-bea7-11e5-9a4e-ebb91a1d3931.png)

![screenshot-localhost 5001 2016-01-19 12-22-10](https://cloud.githubusercontent.com/assets/170528/12408848/eca51254-bea7-11e5-8dea-59312f54209a.png)

위 버튼은 토글입니다.