### PR TITLE
Display user's body size at the order time

### DIFF
--- a/templates/order-id.html.haml
+++ b/templates/order-id.html.haml
@@ -289,6 +289,25 @@
                                         >#{ $order->compensation_pay_with || q{결제 방법 선택} }</a>
                                       \/
                                       %strong.compensation-final 0원
+                                  %li.row
+                                    .col-sm-1
+                                      %i.icon-caret-right.green
+                                    .col-sm-3.no-padding-left 주문 신체 치수:
+                                    .col-sm-8
+                                      %span.label.label-success= $order->height   || '-'
+                                      %span.label.label-success= $order->weight   || '-'
+                                      %br
+                                      %span.label.label-info=    $order->bust     || '-'
+                                      %span.label.label-info=    $order->waist    || '-'
+                                      %span.label.label-info=    $order->hip      || '-'
+                                      %span.label.label-info=    $order->topbelly || '-'
+                                      %span.label.label-info=    $order->belly    || '-'
+                                      %br
+                                      %span.label.label-warning= $order->thigh    || '-'
+                                      %span.label.label-warning= $order->arm      || '-'
+                                      %span.label.label-warning= $order->leg      || '-'
+                                      %span.label.label-warning= $order->knee     || '-'
+                                      %span.label.label-warning= $order->foot     || '-'
                             /
                             / 대여자 정보
                             /


### PR DESCRIPTION
#612 중 일부내용을 해결하는 이슈입니다. 단순 템플릿 수정입니다.

----

우측에 표시되는 사용자의 (최종)신체 치수와 유사하게 주문시점의
신체치수를 표시합니다.