### PR TITLE
Feature/#706 order custom return date

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+  - 주문서에 `today` parameter 를 반납일(return_date) 로 사용가능하도록 함
+
 v1.0.1    Fri, 12 Feb 2016 12:17:26 +0900
   - Rollback Check email duplication at reservation(55c1173)
 

--- a/bin/opencloset.pl
+++ b/bin/opencloset.pl
@@ -260,7 +260,7 @@ helper commify => sub {
 helper calc_late_fee => sub {
     my ( $self, $order, $today ) = @_;
 
-    my $price   = $self->order_clothes_price($order);
+    my $price = $self->order_clothes_price($order);
     my $overdue = $self->calc_overdue( $order, $today );
     return 0 unless $overdue;
 

--- a/coffee/order-id.coffee
+++ b/coffee/order-id.coffee
@@ -3,6 +3,7 @@ $ ->
     order_id = $('#order').data('order-id')
     $.ajax "/api/order/#{ order_id }.json",
       type: 'GET'
+      data: { today: $('#order').data('today') }
       success: (data, textStatus, jqXHR) ->
         $('#order').data('order-clothes-price',     data.clothes_price)
         $('#order').data('order-late-fee',          data.late_fee)
@@ -358,6 +359,10 @@ $ ->
         desc:        "환불 수수료: #{charge}원"
         stage:       3
       }
+    #
+    # 반납일
+    #
+    today = $('#order').data('today')
     returnClothesReal 'refund', "/order/#{order_id}", order_id, '결제 방법 선택', '결제 방법 선택'
 
   #
@@ -403,7 +408,12 @@ $ ->
       complete: ->
         $this.removeClass('disabled')
 
-  returnClothesReal = (type, redirect_url, order_id, late_fee_pay_with, compensation_pay_with) ->
+  returnClothesReal = (type, redirect_url, order_id, late_fee_pay_with, compensation_pay_with, today) ->
+    if today and /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(today)
+      return_date = moment().format(today)
+    else
+      return_date = moment().format('YYYY-MM-DD HH:mm:ss')
+
     if type is 'part'
       #
       # 부분 반납
@@ -416,7 +426,7 @@ $ ->
       url  = "/api/order/#{ order_id }/return-part.json"
       data =
         status_id:              9
-        return_date:            moment().format('YYYY-MM-DD HH:mm:ss')
+        return_date:            return_date
         late_fee_pay_with:      late_fee_pay_with
         order_detail_id:        order_detail_id
     else if type is 'refund'
@@ -430,7 +440,7 @@ $ ->
       url  = "/api/order/#{ order_id }.json"
       data =
         status_id:              42
-        return_date:            moment().format('YYYY-MM-DD HH:mm:ss')
+        return_date:            return_date
         late_fee_pay_with:      late_fee_pay_with
         compensation_pay_with:  compensation_pay_with
         order_detail_id:        order_detail_id
@@ -446,7 +456,7 @@ $ ->
       url  = "/api/order/#{ order_id }.json"
       data =
         status_id:              9
-        return_date:            moment().format('YYYY-MM-DD HH:mm:ss')
+        return_date:            return_date
         late_fee_pay_with:      late_fee_pay_with
         compensation_pay_with:  compensation_pay_with
         order_detail_id:        order_detail_id
@@ -541,7 +551,12 @@ $ ->
                 stage:       2
               }
 
-    returnClothesReal type, redirect_url, order_id, late_fee_pay_with, compensation_pay_with
+    #
+    # 반납일
+    #
+    today = $('#order').data('today')
+
+    returnClothesReal type, redirect_url, order_id, late_fee_pay_with, compensation_pay_with, today
 
   #
   # 전체 반납 버튼 클릭

--- a/cpanfile
+++ b/cpanfile
@@ -3,6 +3,7 @@ requires 'Data::Pageset';
 requires 'DateTime';
 requires 'DateTime::Format::Duration';
 requires 'DateTime::Format::Human::Duration', '0.62';
+requires 'DateTime::Format::Strptime';
 requires 'FindBin';
 requires 'Getopt::Long::Descriptive';
 requires 'Gravatar::URL';

--- a/templates/order-id.html.haml
+++ b/templates/order-id.html.haml
@@ -21,7 +21,7 @@
 - my %analyze = $order->analyze_order_status_logs;
 - my @process = (qw/대기 치수측정 의류준비 탈의 포장 수선 결제/);
 
-                .row#order{ 'data-order-id' => "#{ $order->id }", 'data-order-parent-id' => "#{ $order->parent_id // q{} } ", 'data-url' => "#{ url_for( '/api/order/' . $order->id ) }" }
+                .row#order{ 'data-order-id' => "#{ $order->id }", 'data-order-parent-id' => "#{ $order->parent_id // q{} } ", 'data-url' => "#{ url_for( '/api/order/' . $order->id ) }", 'data-today' => "#{ $today // q{} }" }
                   .col-sm-10.col-sm-offset-1
                     .widget-box.transparent.invoice-box
                       /


### PR DESCRIPTION
다음 두 요청에 대해 `today` 인자를 추가하고 해당 인자가 있을 경우 오늘을 현 시점이 아닌 인자 값으로 인식해서 연체 여부를 결정합니다. 인자 가운데의 `%20`은 공백을 의미합니다.

- `/api/order/14340.json?today=2015-10-16%2018:00:00`
- `/order/14340?today=2015-10-16%2018:00:00`

인식하는 날짜 형식은 다음과 같습니다.

`2015-10-16 18:00:00`

그 외 날짜 형식의 경우 오류로 처리합니다.
