### PR TITLE
쿠폰코드를 입력하고 주문서에서 사용할 수 있도록 함

### DIFF
--- a/coffee/bundle.coffee
+++ b/coffee/bundle.coffee
@@ -127,6 +127,9 @@ $ ->
       '현금영수증',
       '세금계산서',
       '미납',
+      '쿠폰',
+      '쿠폰+현금',
+      '쿠폰+카드'
     ]
     trimClothesCode: (code) ->
       code = code.replace /^\s+/, ''

--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
+requires 'Algorithm::CouponCode';
 requires 'CHI';
 requires 'Data::Pageset';
 requires 'DateTime';

--- a/less/coupon.less
+++ b/less/coupon.less
@@ -5,11 +5,14 @@ body {
     background-color: #fedc00;
     padding-top: 10px;
 }
-.btn-submit {
+.btn-submit, .alert {
     margin-top: 20px;
 }
 h1 {
     color: #000;
+}
+input[type=text] {
+    text-transform: uppercase;
 }
 
 @media (min-width: 768px) {

--- a/less/coupon.less
+++ b/less/coupon.less
@@ -1,0 +1,19 @@
+body {
+    width: 100%;
+    height: 100%;
+    min-height: 100%;
+    background-color: #fedc00;
+    padding-top: 10px;
+}
+.btn-submit {
+    margin-top: 20px;
+}
+h1 {
+    color: #000;
+}
+
+@media (min-width: 768px) {
+    body {
+        padding-top: 300px;
+    }
+}

--- a/lib/OpenCloset/Web.pm
+++ b/lib/OpenCloset/Web.pm
@@ -181,7 +181,7 @@ sub _public_routes_visit {
     $r->any('/visit')->to('booking#visit');
 
     $r->get('/coupon')->to('coupon#index');
-    $r->get('/coupon/:code/validate')->to('coupon#validate');
+    $r->post('/coupon/validate')->to('coupon#validate');
 }
 
 =head2 _private_routes

--- a/lib/OpenCloset/Web.pm
+++ b/lib/OpenCloset/Web.pm
@@ -179,6 +179,9 @@ sub _public_routes_visit {
     my $r    = $self->routes;
 
     $r->any('/visit')->to('booking#visit');
+
+    $r->get('/coupon')->to('coupon#index');
+    $r->get('/coupon/:code/validate')->to('coupon#validate');
 }
 
 =head2 _private_routes

--- a/lib/OpenCloset/Web/Controller/Booking.pm
+++ b/lib/OpenCloset/Web/Controller/Booking.pm
@@ -221,11 +221,18 @@ sub visit {
                     #
                     # 예약 정보가 없는 경우 - 신규 예약 신청 상황
                     #
+                    my $coupon_id;
+                    if ( my $code = delete $self->session->{coupon_code} ) {
+                        my $coupon = $self->DB->resultset('Coupon')->find( { code => $code } );
+                        $coupon_id = $coupon->id;
+                    }
+
                     my $order_obj = $user->create_related(
                         'orders',
                         {
-                            status_id  => 14,      # 방문예약: status 테이블 참조
+                            status_id  => 14,        # 방문예약: status 테이블 참조
                             booking_id => $booking,
+                            coupon_id  => $coupon_id,
                         }
                     );
                     if ($order_obj) {

--- a/lib/OpenCloset/Web/Controller/Coupon.pm
+++ b/lib/OpenCloset/Web/Controller/Coupon.pm
@@ -43,7 +43,7 @@ sub validate {
     my $codes = $v->every_param('code');
     my $code = join( '-', @$codes );
 
-    my ( $valid_code, $err_code ) = $self->_validate($code);
+    my ( $valid_code, $err_code ) = $self->_validate_code($code);
     if ($valid_code) {
         $self->session( coupon_code => $valid_code );
         $self->redirect_to('/visit');
@@ -54,7 +54,7 @@ sub validate {
     }
 }
 
-sub _validate {
+sub _validate_code {
     my ( $self, $code ) = @_;
 
     my $valid_code = cc_validate( code => $code, parts => 3 );

--- a/lib/OpenCloset/Web/Controller/Coupon.pm
+++ b/lib/OpenCloset/Web/Controller/Coupon.pm
@@ -1,0 +1,26 @@
+package OpenCloset::Web::Controller::Coupon;
+use Mojo::Base 'Mojolicious::Controller';
+
+has DB => sub { shift->app->DB };
+
+=head1 METHODS
+
+=head2 index
+
+    GET /coupon
+
+=cut
+
+sub index { }
+
+=head2 validate
+
+    GET /coupon/:code/validate
+
+=cut
+
+sub validate {
+    my $self = shift;
+}
+
+1;

--- a/lib/OpenCloset/Web/Controller/Coupon.pm
+++ b/lib/OpenCloset/Web/Controller/Coupon.pm
@@ -1,6 +1,16 @@
 package OpenCloset::Web::Controller::Coupon;
 use Mojo::Base 'Mojolicious::Controller';
 
+use Algorithm::CouponCode qw(cc_validate);
+use DateTime;
+
+our %ERROR_MAP = (
+    1 => '유효하지 않은 코드 입니다',
+    2 => '없는 쿠폰 입니다',
+    3 => '사용할 수 없는 쿠폰입니다',
+    4 => '유효기간이 지난 쿠폰입니다',
+);
+
 has DB => sub { shift->app->DB };
 
 =head1 METHODS
@@ -15,12 +25,53 @@ sub index { }
 
 =head2 validate
 
-    GET /coupon/:code/validate
+    POST /coupon/validate
 
 =cut
 
 sub validate {
     my $self = shift;
+
+    my $v = $self->validation;
+
+    $v->required('code');
+    if ( $v->has_error ) {
+        $self->flash( error => 'coupon 코드를 입력해주세요' );
+        return $self->redirect_to('/coupon');
+    }
+
+    my $codes = $v->every_param('code');
+    my $code = join( '-', @$codes );
+
+    my ( $valid_code, $err_code ) = $self->_validate($code);
+    if ($valid_code) {
+        $self->session( coupon_code => $valid_code );
+        $self->redirect_to('/visit');
+    }
+    else {
+        $self->flash( error => $ERROR_MAP{$err_code} );
+        $self->redirect_to('/coupon');
+    }
+}
+
+sub _validate {
+    my ( $self, $code ) = @_;
+
+    my $valid_code = cc_validate( code => $code, parts => 3 );
+    return ( undef, 1 ) unless $valid_code;
+
+    my $coupon = $self->DB->resultset('Coupon')->find( { code => $valid_code } );
+    return ( undef, 2 ) unless $coupon;
+
+    if ( my $coupon_status = $coupon->status ) {
+        return ( undef, 3 ) if $coupon_status =~ m/(us|discard)ed/;
+    }
+
+    if ( my $expires = $coupon->expires_date ) {
+        return ( undef, 4 ) if $expires->epoch < DateTime->now->epoch;
+    }
+
+    return $valid_code;
 }
 
 1;

--- a/lib/OpenCloset/Web/Controller/Order.pm
+++ b/lib/OpenCloset/Web/Controller/Order.pm
@@ -357,31 +357,32 @@ sub order {
     # 결제 대기 상태이면 사용자의 정보를 주문서에 동기화 시킴
     #
     if ( $order->status_id == 19 ) {
-        my $user    = $order->user;
-        my $comment = $user->user_info->comment ? $user->user_info->comment . "\n" : q{};
-        my $desc    = $order->desc ? $order->desc . "\n" : q{};
+        my $user      = $order->user;
+        my $user_info = $user->user_info;
+        my $comment   = $user_info->comment ? $user_info->comment . "\n" : q{};
+        my $desc      = $order->desc ? $order->desc . "\n" : q{};
         $order->update(
             {
-                wearon_date  => $user->user_info->wearon_date,
-                purpose      => $user->user_info->purpose,
-                purpose2     => $user->user_info->purpose2,
-                pre_category => $user->user_info->pre_category,
-                pre_color    => $user->user_info->pre_color,
-                height       => $user->user_info->height,
-                weight       => $user->user_info->weight,
-                neck         => $user->user_info->neck,
-                bust         => $user->user_info->bust,
-                waist        => $user->user_info->waist,
-                hip          => $user->user_info->hip,
-                topbelly     => $user->user_info->topbelly,
-                belly        => $user->user_info->belly,
-                thigh        => $user->user_info->thigh,
-                arm          => $user->user_info->arm,
-                leg          => $user->user_info->leg,
-                knee         => $user->user_info->knee,
-                foot         => $user->user_info->foot,
-                pants        => $user->user_info->pants,
-                skirt        => $user->user_info->skirt,
+                wearon_date  => $user_info->wearon_date,
+                purpose      => $user_info->purpose,
+                purpose2     => $user_info->purpose2,
+                pre_category => $user_info->pre_category,
+                pre_color    => $user_info->pre_color,
+                height       => $user_info->height,
+                weight       => $user_info->weight,
+                neck         => $user_info->neck,
+                bust         => $user_info->bust,
+                waist        => $user_info->waist,
+                hip          => $user_info->hip,
+                topbelly     => $user_info->topbelly,
+                belly        => $user_info->belly,
+                thigh        => $user_info->thigh,
+                arm          => $user_info->arm,
+                leg          => $user_info->leg,
+                knee         => $user_info->knee,
+                foot         => $user_info->foot,
+                pants        => $user_info->pants,
+                skirt        => $user_info->skirt,
                 desc         => $comment . $desc,
             }
         );

--- a/lib/OpenCloset/Web/Controller/Order.pm
+++ b/lib/OpenCloset/Web/Controller/Order.pm
@@ -495,6 +495,17 @@ sub update {
 
                         $self->app->log->error("Failed to create a new SMS: $msg") unless $sms;
                     }
+
+                    #
+                    # 쿠폰의 상태를 변경
+                    #
+                    #   결제방식이 쿠폰(+현금|+카드)?
+                    #
+                    if ( my $coupon = $order->coupon ) {
+                        if ( $order->price_pay_with =~ m/쿠폰/ ) {
+                            $coupon->update( { status => 'used' } );
+                        }
+                    }
                 }
 
                 #

--- a/lib/OpenCloset/Web/Controller/Order.pm
+++ b/lib/OpenCloset/Web/Controller/Order.pm
@@ -294,6 +294,16 @@ sub create {
                 { name => '에누리', price => 0, final_price => 0, } )
                 or die "failed to create a new order_detail for discount\n";
 
+            #
+            # 쿠폰을 사용했다면 결제방법을 입력
+            #
+            if ( my $coupon = $order->coupon ) {
+                my $type           = $coupon->type;
+                my $price_pay_with = '쿠폰';
+                $price_pay_with .= '+현금' if $type eq 'default';
+                $order->update( { price_pay_with => $price_pay_with } );
+            }
+
             $guard->commit;
 
             return $order;

--- a/templates/coupon/index.html.ep
+++ b/templates/coupon/index.html.ep
@@ -7,16 +7,16 @@
 </div>
 
 <div class="text-center">
-  <form>
+  <form method="POST" action="<%= url_for('/coupon/validate') %>">
     <div class="row">
       <div class="col-md-4">
-        <input type="text" class="form-control input-lg" placeholder="GJ8U">
+        <input type="text" name="code" class="form-control input-lg" placeholder="GJ8U">
       </div>
       <div class="col-md-4">
-        <input type="text" class="form-control input-lg" placeholder="QY87">
+        <input type="text" name="code" class="form-control input-lg" placeholder="QY87">
       </div>
       <div class="col-md-4">
-        <input type="text" class="form-control input-lg" placeholder="JY9L">
+        <input type="text" name="code" class="form-control input-lg" placeholder="JY9L">
       </div>
 
       <div class="col-md-12 btn-submit">
@@ -24,4 +24,8 @@
       </div>
     </div>
   </form>
+
+  % if (my $error = flash('error')) {
+  <div class="alert alert-danger" role="alert"><%= $error %></div>
+  % }
 </div>

--- a/templates/coupon/index.html.ep
+++ b/templates/coupon/index.html.ep
@@ -1,0 +1,27 @@
+% title '열린옷장 쿠폰';
+% layout 'coupon';
+
+<div class="text-center">
+  <h1>열린옷장 쿠폰</h1>
+  <p>쿠폰번호를 입력하시고 방문예약하시면 의류 한셋트를 대여해드립니다</p>
+</div>
+
+<div class="text-center">
+  <form>
+    <div class="row">
+      <div class="col-md-4">
+        <input type="text" class="form-control input-lg" placeholder="GJ8U">
+      </div>
+      <div class="col-md-4">
+        <input type="text" class="form-control input-lg" placeholder="QY87">
+      </div>
+      <div class="col-md-4">
+        <input type="text" class="form-control input-lg" placeholder="JY9L">
+      </div>
+
+      <div class="col-md-12 btn-submit">
+        <button type="submit" class="btn btn-success btn-lg btn-block">입력</button>
+      </div>
+    </div>
+  </form>
+</div>

--- a/templates/layouts/coupon.html.ep
+++ b/templates/layouts/coupon.html.ep
@@ -13,6 +13,13 @@
 
     <script src="/components/jquery/dist/jquery.min.js"></script>
     <script src="/components/bootstrap/dist/js/bootstrap.min.js"></script>
+    <script src="/components/jquery-mask-plugin/dist/jquery.mask.js"></script>
+
+    <script>
+      $(function() {
+        return $('input[name=code]').mask('AAAA');
+      });
+    </script>
 
     <title><%= title %> - 열린옷장</title>
   </head>

--- a/templates/layouts/coupon.html.ep
+++ b/templates/layouts/coupon.html.ep
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <link href="/components/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/components/opencloset.css/dist/css/opencloset.min.css" rel="stylesheet">
+    <link href="/css/coupon.min.css" rel="stylesheet">
+
+    <script src="/components/jquery/dist/jquery.min.js"></script>
+    <script src="/components/bootstrap/dist/js/bootstrap.min.js"></script>
+
+    <title><%= title %> - 열린옷장</title>
+  </head>
+
+  <body>
+    <div class="container">
+      <%= content %>
+    </div>
+  </body>
+</html>

--- a/templates/order/order.html.haml
+++ b/templates/order/order.html.haml
@@ -195,6 +195,7 @@
                         ></a>
                       \/
                       %strong.order-stage0-price 0원
+                      = coupon2label($order->coupon)
                   - if ( $order_status eq '대여중' ) {
                     %li.row
                       .col-sm-1


### PR DESCRIPTION
#730 

유효한 쿠폰번호를 입력한 사용자는 visit.theopencloset.net/visit 으로 이동되어서 방문예약을 할 수 있습니다.
절차는 같습니다만 프로그램에서 사용자를 구분해서 쿠폰을 입력한 사용자를 구분합니다.

결제대기로 넘어갈때 쿠폰이 등록된 주문서의 결제방식은 `쿠폰` 으로 변경되고,
주문서에서 쿠폰의 가격, 상태등을 볼 수 있습니다.

![screenshot-localhost 5001 2016-03-12 14-12-35](https://cloud.githubusercontent.com/assets/170528/13721035/c8421f36-e85c-11e5-973c-18afd054926b.png)
![screenshot-localhost 5001 2016-03-12 14-12-56](https://cloud.githubusercontent.com/assets/170528/13721036/c8428d9a-e85c-11e5-95e3-3566edaa3496.png)
![screenshot-localhost 5001 2016-03-12 14-13-58](https://cloud.githubusercontent.com/assets/170528/13721037/c84a2ed8-e85c-11e5-89ac-5539beee1a52.png)
