### PR TITLE
Remove not-using mojolicious plugin

### DIFF
--- a/lib/OpenCloset/Web.pm
+++ b/lib/OpenCloset/Web.pm
@@ -57,7 +57,6 @@ sub startup {
 
     $self->plugin('validator');
     $self->plugin('haml_renderer');
-    $self->plugin('FillInFormLite');
     $self->plugin('OpenCloset::Web::Plugin::Helpers');
 
     $self->_authentication;


### PR DESCRIPTION
사용하지 않는 [Mojolicious::Plugin::FillInForm 플러그인](https://metacpan.org/pod/Mojolicious::Plugin::FillInFormLite)을 제거합니다.
`cpanfile` 에서 의존성은 89717da 에서 제거했습니다.