### PR TITLE
Remove warning: smartmatch (#827)

### DIFF
--- a/lib/OpenCloset/Web/Controller/Clothes.pm
+++ b/lib/OpenCloset/Web/Controller/Clothes.pm
@@ -331,24 +331,28 @@ sub clothes_pdf {
 
     my $background_type;
     my $type_str = q{};
-    if ( "온라인" ~~ @tags ) {
-        if ( $clothes->gender eq "male" ) {
-            $background_type = "online-male";
-            $type_str        = "온라인 - 남성";
+    {
+        use experimental qw( smartmatch );
+
+        if ( "온라인" ~~ @tags ) {
+            if ( $clothes->gender eq "male" ) {
+                $background_type = "online-male";
+                $type_str        = "온라인 - 남성";
+            }
+            elsif ( $clothes->gender eq "female" ) {
+                $background_type = "online-female";
+                $type_str        = "온라인 - 여성";
+            }
         }
-        elsif ( $clothes->gender eq "female" ) {
-            $background_type = "online-female";
-            $type_str        = "온라인 - 여성";
-        }
-    }
-    else {
-        if ( $clothes->gender eq "male" ) {
-            $background_type = "offline-male";
-            $type_str        = "오프라인 - 남성";
-        }
-        elsif ( $clothes->gender eq "female" ) {
-            $background_type = "offline-female";
-            $type_str        = "오프라인 - 여성";
+        else {
+            if ( $clothes->gender eq "male" ) {
+                $background_type = "offline-male";
+                $type_str        = "오프라인 - 남성";
+            }
+            elsif ( $clothes->gender eq "female" ) {
+                $background_type = "offline-female";
+                $type_str        = "오프라인 - 여성";
+            }
         }
     }
 


### PR DESCRIPTION
#827 

똑똑한 일치를 쓸 경우 최신 버전의 펄 들의 경우 명시적으로 experimental 기능의 사용 여부를 알려야 합니다. 관련해서 블록으로 지정하고 해당 구역에서 명시적으로 사용하도록 수정했습니다.