### PR TITLE
Do not convert cuff to inch after OpenCloset::Schema 0.032

### DIFF
--- a/lib/OpenCloset/Web/Controller/Clothes.pm
+++ b/lib/OpenCloset/Web/Controller/Clothes.pm
@@ -325,7 +325,7 @@ sub clothes_pdf {
     $hip           ||= "-";
     $thigh         ||= "-";
     $length_bottom ||= "-";
-    $cuff = $cuff ? sprintf( "%.2f", $cuff * 100 / 254 ) : "-";
+    $cuff          ||= "-";
 
     my @tags = map { $_->name } $clothes->tags;
 


### PR DESCRIPTION
#839 

OpenCloset::Schema 0.032 버전 이후부터는 DBIC 메소드를 이용해서 `cuff` 값을 구해올 경우 인치 값으로 변경이 된 상태이므로 해당 값을 인치로 변환하면 중복 변환이 되므로 변환하면 안됩니다.