### PR TITLE
#1190 search by order API 추가

### DIFF
--- a/lib/OpenCloset/Web.pm
+++ b/lib/OpenCloset/Web.pm
@@ -230,6 +230,7 @@ sub _private_routes {
     $api->put('/order/:id/booking')->to('API#api_update_order_booking');
     $api->delete('/order/:id/booking')->to('API#api_delete_order_booking');
     $api->get('/order-list')->to('API#api_order_list');
+    $api->get('/order/:id/search/clothes')->to('API#api_search_clothes_order');
 
     ## prevent deep recursion with create_order_detail helper
     $api->post('/order_detail')->to('API#api_create_order_detail');


### PR DESCRIPTION
 - https://github.com/opencloset/OpenCloset-Share-Web/issues/39 를 처리하기 위해 필요 
 - Helper에 `search_clothes` 함수의 기능중 일부를 `api_search_clothes_user`, `user_search_clothes`로 이동시키고 원 함수를 좀 더 범용적으로 사용할 수 있는 함수로 개선
 - `order` 내용을 바탕으로 검색결과를 돌려주는 `/order/:id/search/clothes` API 를 추가

----

신규 배포를 할 경우 설정에 추가되어야 할 내용이 있습니다.(`search_clothes`->{male|female}->{`fix_sizes`}) 주의해서 배포해야 합니다.