### PR TITLE
Feature/#1328 user add oneshot avg button

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- 신체치수 입력란에 평균값을 전부 한번에 넣을 수 있는 버튼의 생성 (#1328)
+
 ### Fixed
 
 - 사용자 정보의 신체 치수의 평균 값이 동적으로 변하지 않음 (#1334)

--- a/RELEASE-TODO.md
+++ b/RELEASE-TODO.md
@@ -1,3 +1,4 @@
+    $ grunt
     $ closetpan OpenCloset::Size::Guess::DB    # 0.008
 
 v1.12.0

--- a/coffee/user-id.coffee
+++ b/coffee/user-id.coffee
@@ -275,3 +275,16 @@ $ ->
         OpenCloset.alert textStatus
       complete: (jqXHR, textStatus) ->
         $this.removeClass('disabled')
+
+  $("#btn-avg-all").on "click", (e) ->
+    for i in [ 'neck', 'belly', 'topbelly', 'bust', 'arm', 'thigh', 'waist', 'hip', 'leg', 'foot', 'knee' ]
+      userValue = $("#user-#{i}").editable "getValue", true
+      console.log "userValue: [#{userValue}]"
+      unless userValue
+        val = $(".#{i} .avg").text()
+        filteredVal = val
+        filteredVal = filteredVal.replace /^\s+|\s+$/, ""
+        filteredVal = filteredVal.replace /[^.0-9]/g, ""
+        if filteredVal
+          $("#user-#{i}").editable "setValue", Math.round( parseInt(filteredVal) )
+          $("#user-#{i}").editable "submit"

--- a/templates/user/user.html.ep
+++ b/templates/user/user.html.ep
@@ -289,8 +289,9 @@ use OpenCloset::Constants::Measurement qw/$HEIGHT $WEIGHT $NECK $BUST $WAIST $HI
                 <div class="profile-info-name"></div>
                 <div class="profile-info-value">
                   <button id="btn-avg-all" class="btn btn-xs btn-warning">
-                    <span>평균값 입력</span>
+                    <span>평균의 반올림값 입력</span>
                   </button>
+                  <small>비어있는 목둘레 ~ 엉덩이둘레에 평균의 반올림값을 자동 입력합니다.</small>
                 </div>
               </div>
 

--- a/templates/user/user.html.ep
+++ b/templates/user/user.html.ep
@@ -285,6 +285,15 @@ use OpenCloset::Constants::Measurement qw/$HEIGHT $WEIGHT $NECK $BUST $WAIST $HI
                 </div>
               % }
 
+              <div class="profile-info-row">
+                <div class="profile-info-name"></div>
+                <div class="profile-info-value">
+                  <button id="btn-avg-all" class="btn btn-xs btn-warning">
+                    <span>평균값 입력</span>
+                  </button>
+                </div>
+              </div>
+
               % for my $part ($NECK, $BUST, $WAIST, $TOPBELLY, $BELLY, $ARM, $LEG, $KNEE, $THIGH, $HIP, $FOOT) {
                 <div class="profile-info-row <%= $part %>">
                   <div class="profile-info-name"><%= $OpenCloset::Constants::Measurement::LABEL_MAP{$part} %></div>


### PR DESCRIPTION
#1328 

비어있는 신체 치수 항목에 대해 버튼을 누르면 평균값의 반올림 값을 자동으로 입력하고 데이터베이스에 저장합니다. 반올림하는 이유는 데이터베이스상 신체 치수 값은 정수형이기 때문입니다. 오해를 줄이기 위해 버튼을 추가하면서 옆에 간단한 설명도 추가합니다.