### PR TITLE
Feature/#1345 fix clothes barcode input

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
+- 의류 정보에서 상하의 셋트를 입력하기 위한 바코드 입력 양식이 보이지 않음 (#1345)
 - 의류 착용일과 예약 방문일 간 차이가 클 경우 대여자에게 경고함 (#1065)
 
 ### Changed

--- a/templates/clothes/clothes.html.ep
+++ b/templates/clothes/clothes.html.ep
@@ -92,10 +92,13 @@ my $system_start_dt = DateTime->new( %{ $config->{start_date} }, time_zone => $c
           </div>
         % } else {
           <form id="form-suit" class="form-inline" action="<%= url_for('/api/suit') %>" method="POST">
-            <input name="<%= $first eq 'J' ? 'code_top' : 'code_bottom' %>" type="hidden" value="<%= $clothes_code %>">
-            <span class="input-group-btn">
-              <button class="btn btn-sm btn-default" type="submit">등록</button>
-            </span>
+            <input name="<%= $first eq "J" ? "code_top" : "code_bottom" %>" type="hidden" value="<%= $clothes_code %>">
+            <div class="input-group">
+              <input name="<%= $first eq "J" ? "code_bottom" : "code_top" %>" class="form-control" type="text" placeholder="code">
+              <span class="input-group-btn">
+                <button class="btn btn-sm btn-default" type="submit">등록</button>
+              </span>
+            </div>
           </form>
         % }
         <hr>


### PR DESCRIPTION
#1345 

haml을 ep로 변경하던 중 `div.input-group` 요소와 그 안의 `input` 요소를 빠뜨려 발생한 문제입니다. 기존 코드와 동일하게 수정합니다.