### PR TITLE
Feature/#1366 coupon expires booking

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- 서울시 쿠폰(seoul-2017-2)의 방문 예약을 마감함 (#1366)
+
 ## [v1.12.4] - Tue, 21 Nov 2017 01:11:03 +0900
 
 ### Added

--- a/app.conf.sample
+++ b/app.conf.sample
@@ -367,11 +367,19 @@ my %BOOKING_SLOT = (
     },
     events => {
         seoul => {
-            key => $ENV{OPENCLOSET_EVENT_SEOUL_KEY} || '',
+            key => $ENV{OPENCLOSET_EVENT_SEOUL_KEY} || q{},
             notification => {
-                from => '',
+                from => q{},
                 to   => [],
-            }
+            },
+        },
+        "seoul-2017-2" => {
+            key => $ENV{OPENCLOSET_EVENT_SEOUL_KEY} || q{},
+            notification => {
+                from => q{},
+                to   => [],
+            },
+            booking_expires => "2017-12-13T23:59:59",
         },
     },
     income => {


### PR DESCRIPTION
#1366 

쿠폰은 발급 기관과 시즌에 따라 고유 번호가 있습니다. 예를 들어 현 시점 기준 서울시 쿠폰의 가장 최신 쿠폰 식별 번호는 "seoul-2017-2"입니다. 현재 해당 쿠폰을 사용하는 경우 예약 가능 일시를 마감해달라는 요청이 있었습니다. 이것은 최초 쿠폰 설계 당시의 유효일시와는 또 다른 개념으로 보입니다. 따라서 이런 쿠폰 카테고리별로 예약 가능 일시를 마감하기 위한 기능을 추가합니다.