### PR TITLE
Feature/#1371 user info undef val

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- 신체 사이즈 수치를 지워도 NULL이 아닌 0이 저장됨 (#1371)
+
 ## [v1.12.6] - Tue, 26 Dec 2017 13:38:31 +0900
 
 ### Changed

--- a/lib/OpenCloset/Web/Plugin/Helpers.pm
+++ b/lib/OpenCloset/Web/Plugin/Helpers.pm
@@ -679,10 +679,18 @@ sub update_user {
             );
         }
 
+        #
+        # [GH #1371] 신체 사이즈 수치를 지워도 NULL이 아닌 0이 저장됨
+        #
+        my %_user_info_params = %$user_info_params;
+        for my $k ( keys %_user_info_params ) {
+            $_user_info_params{$k} = undef if $_user_info_params{$k} eq q{};
+        }
+
         $user->update( \%_user_params )
             or return $self->error( 500, { str => 'failed to update a user', data => {}, } );
 
-        $user->user_info->update( { %$user_info_params, user_id => $user->id, } )
+        $user->user_info->update( { %_user_info_params, user_id => $user->id, } )
             or return $self->error(
             500,
             { str => 'failed to update a user info', data => {}, }


### PR DESCRIPTION
#1371 

사용자 정보 테이블(`user_info`)에 한해 빈 문자열 값으로 갱신을 시도할 경우 `DBIx::Class`에게 `undef` 값을 전달해 MySQL이 `NULL` 값을 저장할 수 있도록 합니다.