### PR TITLE
Feature/#1392 visit fix order history

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- 방문 예약에서 지난 대여 이력을 선택 시 온라인 주문 내역을 열람할 수 없음 (#1392)
+
 ## [v1.12.7] - Wed, 03 Jan 2018 12:38:23 +0900
 
 ### Changed

--- a/templates/visit-info-box.html.ep
+++ b/templates/visit-info-box.html.ep
@@ -1,5 +1,6 @@
 % use utf8;
 % use DateTime;
+% use List::Util;
 % use OpenCloset::Constants::Category ();
 % my $booking;
 % $booking = $order->booking if $order;
@@ -205,14 +206,17 @@
                                   <option value=""></option>
                                   % while (my $order = $orders->next) {
                                     % my $rental_date  = $order->rental_date;
-                                    % my $pre_category = $order->pre_category;
+                                    % next if     $order->parent_id;
                                     % next unless $rental_date;
-                                    % next unless $pre_category;
-                                    % my @temp = split /,/, $order->pre_category;
-                                    % my @categories = map { $OpenCloset::Constants::Category::LABEL_MAP{$_} } @temp;
+                                    % my @category_list;
+                                    % my $rs = $order->clothes;
+                                    % while ( my $c = $rs->next ) {
+                                    %   push @category_list, $OpenCloset::Constants::Category::LABEL_MAP{ $c->category };
+                                    % }
+                                    % my @sorted_uniq_category_list = sort { $a cmp $b } List::Util::uniq @category_list;
                                     <option value="<%= $order->id %>">
                                       %= $rental_date->ymd
-                                      %= join(', ', @categories)
+                                      %= join(', ', @sorted_uniq_category_list)
                                     </option>
                                   % }
                                 </select>


### PR DESCRIPTION
#1392 

방문 예약시 지난 주문 내역을 선택하는 UI에서 온라인 주문 내역을 열람하지 못하는 버그를 수정합니다. 이는 `order.pre_category` 값 기반으로 동작했기 때문인데, 더욱 정확히 `order.order_details.clothes` 값 기반으로 열람할 수 있도록 변경했습니다. 이제는 `pre_category` 값이 없더라도 지난 주문서를 열람하는데 문제가 없습니다. 더불어 이 변경사항으로 인해 당시 희망 의류가 아니라 실제로 대여했던 의류가 보여지는 효과(?)가 있습니다.