### PR TITLE
Feature/#1415 readability return memo

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- 주문서 반납 확인 메모의 가독성을 높이고 첫 화면에서 열람 가능하게 함 (#1415)
+
 ## [v1.12.9] - Mon, 12 Feb 2018 04:47:58 +0900
 
 ### Changed

--- a/RELEASE-TODO.md
+++ b/RELEASE-TODO.md
@@ -1,3 +1,5 @@
+    $ grunt
+
 v1.12.9
 
     $ mysql < db/alter/136-coupon-limit.sql

--- a/less/screen.less
+++ b/less/screen.less
@@ -376,6 +376,12 @@
             }
         }
     }
+    #order-detail {
+        .order-return-memo-emphasis pre {
+          font-size: 2em;
+          font-weight: bold;
+        }
+    }
     #user-list-table table th {
         &:first-child {
             width: 40px;

--- a/templates/home.html.ep
+++ b/templates/home.html.ep
@@ -93,6 +93,7 @@
         <th>상태</th>
         <th>묶음</th>
         <th>태그</th>
+        <th>반납 확인 메모</th>
         <th>기타</th>
       </tr>
     </thead>
@@ -145,6 +146,7 @@
         <span class="label label-default"><%%= tag.name %></span>
       <%% }); %>
     </td> <!-- 태그 -->
+    <td> <%%= order.return_memo %> </td> <!-- 반납 확인 메모 -->
     <td>
       <a href="/orders/<%%= order.id %>"><span class="label label-info arrowed-right arrowed-in">
         <strong>주문서</strong>
@@ -173,6 +175,7 @@
         <span class="label label-default"><%%= tag.name %></span>
       <%% }); %>
     </td> <!-- 태그 -->
+    <td> </td> <!-- 반납 확인 메모 -->
     <td> </td> <!-- 기타 -->
   </tr>
 </script>

--- a/templates/order/detail.html.ep
+++ b/templates/order/detail.html.ep
@@ -36,8 +36,10 @@
 % }
 
 % if (my $memo = $order->return_memo) {
-  <p>반납 확인 메모 4F</p>
-  <pre><%= $memo %></pre>
+  <div class="order-return-memo-emphasis">
+    <p>반납 확인 메모 4F</p>
+    <pre class="bg-info"><%= $memo %></pre>
+  </div>
 % }
 
 <div class="row">


### PR DESCRIPTION
처리한 내역은 다음과 같습니다.

- 주문서 상세 페이지에서 상단의 반납 확인 메모의 글꼴을 굵고 두껍게 적용하고 info 배경색을 지정합니다.
- 첫 화면에서 반납 확인 메모를 확인할 수 있도록 합니다.