### PR TITLE
feature/#1794-fix_price_coupon_generator_for_opencloset

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [쿠폰 발행] 열린옷장 정장대여쿠폰 번호 발행 (#1794)
+  - `bin/event.pl` 쿠폰 생성기가 쿠폰 유형이 `price`일 경우 금액을 지정하지
+     않는 오류 수정
+
 ### Changed
 
 - 추동복일 경우 출력용 의류 태그를 녹색으로 표현 (#1787)

--- a/bin/event.pl
+++ b/bin/event.pl
@@ -197,14 +197,14 @@ EOL
 
     for ( 1 .. $cnt ) {
         my $code = cc_generate( parts => 3 );
-        my $coupon = $schema->resultset('Coupon')->create(
-            {
+        my %coupon_params = (
                 event_id => $event_id,
                 code     => $code,
                 type     => $type,
-            }
+                price    => $price,
         );
-
+        delete $coupon_params{price} unless $type eq 'price' && $price;
+        my $coupon = $schema->resultset('Coupon')->create(\%coupon_params);
         unless ($coupon) {
             print STDERR "Couldn't create a new Coupon\n";
             next;


### PR DESCRIPTION
#1794 

수정한 내역은 다음과 같습니다.

- `bin/event.pl` 쿠폰 생성기가 쿠폰 생성 시 쿠폰 유형이 `price`일 경우 명령줄에서 입력한 `--coupon-price` 값을 적용하지 않는 오류 수정